### PR TITLE
ci: add workflows managing releases

### DIFF
--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -1,0 +1,122 @@
+# #############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+
+
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+categories:
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "bug"
+  - title: "📄 Documentation"
+    labels:
+      - "documentation"
+  - title: "🚀 Features"
+    labels:
+      - "enhancement"
+  - title: "🧰 Maintenance"
+    label: "chore"
+
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+  patch:
+    labels:
+      - "patch"
+  default: patch
+
+autolabeler:
+  - label: "bug"
+    branch:
+      - '/^(bug|fix|bugfix)\/.+/'
+    title:
+      - "/^(bug|fix|bugfix):.+/"
+      - '/^(bug|fix|bugfix)(\(.+\)):.+/'
+  - label: "chore"
+    branch:
+      - '/^(chore)\/.+/'
+    title:
+      - "/^(chore):.+/"
+      - '/^(chore)(\(.+\)):.+/'
+  - label: "documentation"
+    branch:
+      - '/^(docs?|documentation)\/.+/'
+    files:
+      - "*.md"
+    title:
+      - "/^(docs?|documentation):.+/"
+      - '/^(docs?|documentation)(\(.+\)):.+/'
+  - label: "enhancement"
+    branch:
+      - '/^(feat|feature|enhancement)\/.+/'
+    title:
+      - "/^(feat|feature|enhancement):.+/"
+      - '/^(feat|feature|enhancement)(\(.+\)):.+/'
+
+  # label skip-changelog when either title or body or PR indicates GH Action/Workflow
+  # https://regex101.com/r/v15bku/1
+  - label: "skip-changelog"
+    title:
+      - '/([^.+][Gg]it[Hh]ub|[^.+][Gg][Hh][-\s][WwAa][oc][rt]|[^.*][Ww]orkflow|[Aa]ction)/'
+    body:
+      - '/([^.+][Gg]it[Hh]ub|[^.+][Gg][Hh][-\s][WwAa][oc][rt]|[^.*][Ww]orkflow|[Aa]ction)/'
+
+  # version-resolver labels
+  # if a PR only fixes some bugs the patch should be updated
+  - label: "patch"
+    branch:
+      - '/^(fix)\/.+/'
+      - '/^(chore)\/.+/'
+    title:
+      - "/^(bug|fix|bugfix):.+/"
+      - '/^(bug|fix|bugfix)(\(.+\)):.+/'
+      - "/^(chore):.+/"
+      - '/^(chore)(\(.+\)):.+/'
+  # if a PR adds a feature the minor should be updated (when no breaking changes)
+  - label: "minor"
+    branch:
+      - '/^(feat|feature|enhancement)\/.+/'
+    title:
+      - "/^(feat|feature|enhancement):.+/"
+      - '/^(feat|feature|enhancement)(\(.+\)):.+/'
+  # if a PR adds a breaking-change feature the major should be updated
+  - label: "major"
+    branch:
+      - '/^(feat|feature|chore|fix|enhancement)!\/.+/'
+    title:
+      - "/^(feat|feature|chore|fix|enhancement)!:.+/"
+      - '/^(feat|feature|chore|fix|enhancement)(\(.+\))!:.+/'
+    body:
+      - '/BREAKING\ CHANGE/'
+
+exclude-labels:
+  - "skip-changelog"
+
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,38 @@
+# #############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - dependencies
+    authors:
+      - github-actions
+  categories:
+    - title: "🐛 Bug Fixes"
+      labels:
+        - "bug"
+    - title: "📄 Documentation"
+      labels:
+        - "documentation"
+    - title: "🚀 Features"
+      labels:
+        - "enhancement"
+    - title: "🧰 Maintenance"
+      label: "chore"

--- a/.github/workflows/pullRequest-lint.yaml
+++ b/.github/workflows/pullRequest-lint.yaml
@@ -1,0 +1,61 @@
+# #############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+
+name: "Lint PullRequest"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fail, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+            
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+            
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,51 @@
+# #############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # for release-drafter/release-drafter to create a github release
+      pull-requests: write # for release-drafter/release-drafter to add label to PR
+
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,15 +40,6 @@ jobs:
 #      - name: Run
 #        run: go build -ldflags "-s -w" -o $GITHUB_WORKSPACE/.github/bin/
 #        working-directory: $GITHUB_WORKSPACE
-#
-#      - name: Publish changes
-#        run: |
-#          git config user.name github-actions
-#          git config user.email github-actions@github.com
-#          git checkout main
-#          git add .github/bin/helmRepoIndex
-#          git commit -m "chore: update dev helm repo index ($GITHUB_REF)"
-#          git push
 
   release:
     needs: go-build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,66 @@
+# #############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+
+name: Create GitHub Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+# todo (CARSLEN): setup/adjust go build routine according to needs if we're ready to build
+#  go-build:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#        with:
+#          fetch-depth: 0
+#      - name: Set up Go
+#        uses: actions/setup-go@v3
+#        with:
+#          go-version-file: 'main.go'
+#
+#      - name: Run
+#        run: go build -ldflags "-s -w" -o $GITHUB_WORKSPACE/.github/bin/
+#        working-directory: $GITHUB_WORKSPACE
+#
+#      - name: Publish changes
+#        run: |
+#          git config user.name github-actions
+#          git config user.email github-actions@github.com
+#          git checkout main
+#          git add .github/bin/helmRepoIndex
+#          git commit -m "chore: update dev helm repo index ($GITHUB_REF)"
+#          git push
+
+  release:
+    needs: go-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            CHANGELOG.md
+            LICENSE
+            # add build artifact
+          generate_release_notes: true


### PR DESCRIPTION
## What:
Add workflows:

- Pull Request Linter
- Release Drafter
- GH Release


## Why:

These workflows will ensure to build automatically nice GH Release Notes.

### Pull Request Linter

Linting will ensure to have PR titles following conventional commits on which drafter rely on.

### Release Drafter

Drafter will run on 2 actions: When a PR is opened and when a PR is merged. When 

- opened/reopened/syncronized, drafter will autolabel the PR according to the PR title
- merged, drafter will create a release draft. According to the PR title, drafter will select apprpriate semVer based version number. If previous release was for example `v0.1.2`  and the PR title is `feature: Lorem Ipsum dolor` the release draft will bump minor version number to `v0.2.0`.

### GH Release
GH Release will be published when pushing a matching GH Tag to the repositories `main` branch and use the drafted release notes for the release.