### PR TITLE
chore(ci): disable `skipChangelog` autolabeler

### DIFF
--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -78,12 +78,11 @@ autolabeler:
       - '/^(feat|feature|enhancement)(\(.+\)):.+/'
 
   # label skip-changelog when either title or body or PR indicates GH Action/Workflow
-  # https://regex101.com/r/v15bku/1
-  - label: "skip-changelog"
-    title:
-      - '/([^.+][Gg]it[Hh]ub|[^.+][Gg][Hh][-\s][WwAa][oc][rt]|[^.*][Ww]orkflow|[Aa]ction)/'
-    body:
-      - '/([^.+][Gg]it[Hh]ub|[^.+][Gg][Hh][-\s][WwAa][oc][rt]|[^.*][Ww]orkflow|[Aa]ction)/'
+#  - label: "skip-changelog"
+#    title:
+#      - '/([^.+][Gg]it[Hh]ub|[^.+][Gg][Hh][-\s][WwAa][oc][rt]|[^.*][Ww]orkflow|[Aa]ction)/'
+#    body:
+#      - '/([^.+][Gg]it[Hh]ub|[^.+][Gg][Hh][-\s][WwAa][oc][rt]|[^.*][Ww]orkflow|[Aa]ction)/'
 
   # version-resolver labels
   # if a PR only fixes some bugs the patch should be updated

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      # todo: Use Release drafter to release the GH release: https://github.com/release-drafter/release-drafter/blob/master/.github/workflows/release.yml#L45-L65
+      # This will create appropriate tags (vmajorNumber in addition to SemVer tag. With small adjustments tag vminorNum should be possible)
       - name: Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
For now, disable `skipChangelog` autolabeler. After merging PR, changes in GH workflows will be listed in release notes again.