### PR TITLE
chore(ci): refactor gh release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,6 +61,7 @@ jobs:
       - name: create GitHub release
         uses: release-drafter/release-drafter@v5
         with:
+          config-name: release-drafter.yaml
           version: ${{ steps.version.outputs.version }}
           publish: true
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,13 +48,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # todo: Use Release drafter to release the GH release: https://github.com/release-drafter/release-drafter/blob/master/.github/workflows/release.yml#L45-L65
-      # This will create appropriate tags (vmajorNumber in addition to SemVer tag. With small adjustments tag vminorNum should be possible)
-      - name: Release
-        uses: softprops/action-gh-release@v1
+      - name: version
+        id: version
+        run: |
+          tag=${GITHUB_REF/refs\/tags\//}
+          version=${tag#v}
+          major=${version%%.*}
+          echo "tag=${tag}" >> $GITHUB_OUTPUT
+          echo "version=${version}" >> $GITHUB_OUTPUT
+          echo "major=${major}" >> $GITHUB_OUTPUT
+
+      - name: create GitHub release
+        uses: release-drafter/release-drafter@v5
         with:
-          files: |
-            CHANGELOG.md
-            LICENSE
-            # add build artifact
-          generate_release_notes: true
+          version: ${{ steps.version.outputs.version }}
+          publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: force update major tag
+        run: |
+          git tag v${{ steps.version.outputs.major }} ${{ steps.version.outputs.tag }} -f
+          git push origin refs/tags/v${{ steps.version.outputs.major }} -f


### PR DESCRIPTION
This workflow will change the release workflow:
- use release-drafter publish release functionality
- create a major version tag with release and update major version tag with new minor/patch release created

A successful test ([release](https://github.com/carslen/tractusx-quality-checks/releases), [tags](https://github.com/carslen/tractusx-quality-checks/tags)) can be reviewed in the fork, where this PR comes from.

> Note:
This PR should not be merged before the following EF ticket has been implemented: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2872

This EF ticket is to enable workflows to write to our repository, which is required to create new tags by the workflow.