### PR TITLE
feat: check INSTALL.md (TRG 1.02)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Check for changelog existence
+### Added
+
+- Check for `CHANGELOG` existence
+- Introduced interface method `IsOptional`
+- Check for `INSTALL.md` existence
+
 
 ## [0.1.0](https://github.com/eclipse-tractusx/tractusx-quality-checks/releases/tag/v0.1.0) - 2023-03-27
 

--- a/internal/changelog_exists.go
+++ b/internal/changelog_exists.go
@@ -24,6 +24,10 @@ import "os"
 type ChangeLogExists struct {
 }
 
+func (c ChangeLogExists) IsOptional() bool {
+	return false
+}
+
 func NewChangelogExists() *ChangeLogExists {
 	return &ChangeLogExists{}
 }

--- a/internal/globals.go
+++ b/internal/globals.go
@@ -19,20 +19,10 @@
 
 package txqualitychecks
 
-// QualityGuideline defines the QualityGuideline interface with its methods.
-type QualityGuideline interface {
-	Name() string
-	Description() string
-	ExternalDescription() string
-	Test() *QualityResult
-	IsOptional() bool
-}
-
-type QualityResult struct {
-	Passed           bool
-	ErrorDescription string
-}
-
-type Printer interface {
-	Print(message string)
+// ReleaseGuidelines defines a slice of QualityGuidelines the test_runner will
+// test.
+var ReleaseGuidelines = []QualityGuideline{
+	NewReadmeExists(),
+	NewInstallExists(),
+	NewChangelogExists(),
 }

--- a/internal/install_exists.go
+++ b/internal/install_exists.go
@@ -25,7 +25,7 @@ import "os"
 type InstallExists struct {
 }
 
-// NewInstallExists generates a new check based on QualityGuideline interface.
+// NewInstallExists func return a new check based on QualityGuideline interface.
 func NewInstallExists() QualityGuideline {
 	return &InstallExists{}
 }
@@ -39,7 +39,7 @@ func (r *InstallExists) Name() string {
 // Description implements ExternalDescription from interface
 // QualityGuideline and returns a brief description of this test.
 func (r *InstallExists) Description() string {
-	return "A INSTALL.md file contains comprehensive instructions for installation."
+	return "File INSTALL.md contains comprehensive instructions for installation."
 }
 
 // ExternalDescription implements ExternalDescription from interface

--- a/internal/install_exists.go
+++ b/internal/install_exists.go
@@ -63,7 +63,7 @@ func (r *InstallExists) Test() *QualityResult {
 
 	if err != nil {
 		return &QualityResult{
-			ErrorDescription: "Did not find optional INSTALL.md file in current directory.",
+			ErrorDescription: "Optional file INSTALL.md not found in current directory.",
 		}
 	}
 	return &QualityResult{Passed: true}

--- a/internal/install_exists.go
+++ b/internal/install_exists.go
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package txqualitychecks
+
+import "os"
+
+// InstallExists defines a struct for
+type InstallExists struct {
+}
+
+// NewInstallExists generates a new check based on QualityGuideline interface.
+func NewInstallExists() QualityGuideline {
+	return &InstallExists{}
+}
+
+// Name implements ExternalDescription from interface
+// QualityGuideline and returns the name of the test.
+func (r *InstallExists) Name() string {
+	return "TRG 1.02 - INSTALL.md"
+}
+
+// Description implements ExternalDescription from interface
+// QualityGuideline and returns a brief description of this test.
+func (r *InstallExists) Description() string {
+	return "A INSTALL.md file contains comprehensive instructions for installation."
+}
+
+// ExternalDescription implements ExternalDescription from interface
+// QualityGuideline and returns an external description like a URL with further
+// details for this test.
+func (r *InstallExists) ExternalDescription() string {
+	return "https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-2"
+}
+
+// IsOptional implements IsOptional from interface QualityGuideline to control if
+// the test is optional.
+func (r *InstallExists) IsOptional() bool {
+	return true
+}
+
+// Test implements the test if optional file INSTALL.md exists. If file is
+// missing an error description is added to QualityResult and Passed set to
+// false, other it returns QualityResult Passed true.
+func (r *InstallExists) Test() *QualityResult {
+	_, err := os.Stat("INSTALL.md")
+
+	if err != nil {
+		return &QualityResult{
+			ErrorDescription: "Did not find optional INSTALL.md file in current directory.",
+		}
+	}
+	return &QualityResult{Passed: true}
+}

--- a/internal/install_exists.go
+++ b/internal/install_exists.go
@@ -21,43 +21,26 @@ package txqualitychecks
 
 import "os"
 
-// InstallExists defines a struct for
 type InstallExists struct {
 }
 
-// NewInstallExists func return a new check based on QualityGuideline interface.
+// NewInstallExists returns a new check based on QualityGuideline interface.
 func NewInstallExists() QualityGuideline {
 	return &InstallExists{}
 }
 
-// Name implements ExternalDescription from interface
-// QualityGuideline and returns the name of the test.
 func (r *InstallExists) Name() string {
 	return "TRG 1.02 - INSTALL.md"
 }
 
-// Description implements ExternalDescription from interface
-// QualityGuideline and returns a brief description of this test.
 func (r *InstallExists) Description() string {
 	return "File INSTALL.md contains comprehensive instructions for installation."
 }
 
-// ExternalDescription implements ExternalDescription from interface
-// QualityGuideline and returns an external description like a URL with further
-// details for this test.
 func (r *InstallExists) ExternalDescription() string {
 	return "https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-2"
 }
 
-// IsOptional implements IsOptional from interface QualityGuideline to control if
-// the test is optional.
-func (r *InstallExists) IsOptional() bool {
-	return true
-}
-
-// Test implements the test if optional file INSTALL.md exists. If file is
-// missing an error description is added to QualityResult and Passed set to
-// false, other it returns QualityResult Passed true.
 func (r *InstallExists) Test() *QualityResult {
 	_, err := os.Stat("INSTALL.md")
 
@@ -67,4 +50,8 @@ func (r *InstallExists) Test() *QualityResult {
 		}
 	}
 	return &QualityResult{Passed: true}
+}
+
+func (r *InstallExists) IsOptional() bool {
+	return true
 }

--- a/internal/install_exists_test.go
+++ b/internal/install_exists_test.go
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package txqualitychecks
+
+import (
+	"os"
+	"testing"
+)
+
+func TestNewInstallExists(t *testing.T) {
+	t.Run("Provide ErrorDescription on Fail", func(t *testing.T) {
+		installTest := NewInstallExists()
+		expectedError := "Did not find optional INSTALL.md file in current directory."
+
+		result := installTest.Test()
+
+		if result.ErrorDescription != expectedError {
+			t.Errorf("Install.md check does not provide correct error description fon failing check!\n"+
+				"expected: %s\ngot: %s", expectedError, result.ErrorDescription)
+		}
+	})
+	t.Run("Pass if file exists", func(t *testing.T) {
+		installTest := NewInstallExists()
+		_, err := os.Create("INSTALL.md")
+		if err != nil {
+			return
+		}
+
+		result := installTest.Test()
+
+		if !result.Passed {
+			t.Errorf("INSTALL exists, but test still fails")
+		}
+
+		err = os.Remove("INSTALL.md")
+		if err != nil {
+			return
+		}
+	})
+	t.Run("No ErrorDescription if test pass", func(t *testing.T) {
+		installTest := NewInstallExists()
+		_, err := os.Create("INSTALL.md")
+		if err != nil {
+			return
+		}
+
+		result := installTest.Test()
+
+		if result.ErrorDescription != "" {
+			t.Errorf("Passing test should not contain an error description")
+		}
+
+		err = os.Remove("INSTALL.md")
+		if err != nil {
+			return
+		}
+	})
+}

--- a/internal/install_exists_test.go
+++ b/internal/install_exists_test.go
@@ -40,7 +40,7 @@ func TestNewInstallExists(t *testing.T) {
 		installTest := NewInstallExists()
 		_, err := os.Create("INSTALL.md")
 		if err != nil {
-			return
+			t.Errorf("Error creating test preconditions!")
 		}
 
 		result := installTest.Test()
@@ -51,14 +51,14 @@ func TestNewInstallExists(t *testing.T) {
 
 		err = os.Remove("INSTALL.md")
 		if err != nil {
-			return
+			t.Errorf("Error while removing test preconditions!")
 		}
 	})
 	t.Run("No ErrorDescription if test pass", func(t *testing.T) {
 		installTest := NewInstallExists()
 		_, err := os.Create("INSTALL.md")
 		if err != nil {
-			return
+			t.Errorf("Error creating test preconditions!")
 		}
 
 		result := installTest.Test()
@@ -69,7 +69,7 @@ func TestNewInstallExists(t *testing.T) {
 
 		err = os.Remove("INSTALL.md")
 		if err != nil {
-			return
+			t.Errorf("Error while removing test preconditions!")
 		}
 	})
 }

--- a/internal/readme_exists.go
+++ b/internal/readme_exists.go
@@ -24,6 +24,10 @@ import "os"
 type ReadmeExists struct {
 }
 
+func (r *ReadmeExists) IsOptional() bool {
+	return false
+}
+
 func NewReadmeExists() QualityGuideline {
 	return &ReadmeExists{}
 }

--- a/internal/test_runner.go
+++ b/internal/test_runner.go
@@ -39,11 +39,19 @@ func (runner *GuidelineTestRunner) Run() error {
 		runner.printer.Print(fmt.Sprintf("Testing Quality Guideline: %s", guideline.Name()))
 
 		result := guideline.Test()
-		if !result.Passed {
-			runner.printer.Print(fmt.Sprintf("Failed! Guideline description: %s; More infos: %s", guideline.Description(), guideline.ExternalDescription()))
+		if guideline.IsOptional() && !result.Passed {
+			runner.printer.Print(
+				fmt.Sprintf("Failed! Test failed, but marked as optional. More infos: %s\n%s",
+					result.ErrorDescription, guideline.ExternalDescription()),
+			)
+		} else if !result.Passed {
+			runner.printer.Print(
+				fmt.Sprintf("Failed! Guideline description: %s\n\t%s\n\tMore infos: %s",
+					guideline.Description(), result.ErrorDescription, guideline.ExternalDescription()),
+			)
 		}
 
-		allPassed = allPassed && result.Passed
+		allPassed = allPassed && (result.Passed || guideline.IsOptional())
 	}
 
 	if !allPassed {

--- a/internal/test_runner.go
+++ b/internal/test_runner.go
@@ -41,8 +41,8 @@ func (runner *GuidelineTestRunner) Run() error {
 		result := guideline.Test()
 		if guideline.IsOptional() && !result.Passed {
 			runner.printer.Print(
-				fmt.Sprintf("Failed! Test failed, but marked as optional. More infos: %s\n%s",
-					result.ErrorDescription, guideline.ExternalDescription()),
+				fmt.Sprintf("Warning! Test failed, but test '%s' is marked as optional.\nMore infos:\n\t%s\n\t%s",
+					guideline.Name(), result.ErrorDescription, guideline.ExternalDescription()),
 			)
 		} else if !result.Passed {
 			runner.printer.Print(

--- a/internal/test_runner_mock.go
+++ b/internal/test_runner_mock.go
@@ -21,10 +21,19 @@ package txqualitychecks
 
 import "fmt"
 
-type FailingQualityGuideline struct {
+type Guideline struct {
 	name                string
 	description         string
 	externalDescription string
+	isOptional          bool
+}
+
+type FailingQualityGuideline struct {
+	Guideline
+}
+
+func (f FailingQualityGuideline) IsOptional() bool {
+	return f.isOptional
 }
 
 func (f FailingQualityGuideline) Name() string {
@@ -44,9 +53,11 @@ func (f FailingQualityGuideline) Test() *QualityResult {
 }
 
 type PassingQualityGuideline struct {
-	name                string
-	description         string
-	externalDescription string
+	Guideline
+}
+
+func (p PassingQualityGuideline) IsOptional() bool {
+	return p.isOptional
 }
 
 func (p PassingQualityGuideline) Name() string {

--- a/internal/test_runner_test.go
+++ b/internal/test_runner_test.go
@@ -144,3 +144,21 @@ func allMessages(messages []string) string {
 
 	return result
 }
+
+func TestShouldNotFailIfOptionalTestFail(t *testing.T) {
+	failingGuideline := &FailingQualityGuideline{
+		Guideline{
+			name:                "TRG 1.02 - INSTALL.md",
+			description:         "Optional content should not fail a test",
+			externalDescription: "https://github.com/",
+			isOptional:          true,
+		},
+	}
+
+	runner := NewTestRunner([]QualityGuideline{failingGuideline})
+	err := runner.Run()
+
+	if err != nil {
+		t.Errorf("Optional Guidlines should not make the runner fail!")
+	}
+}

--- a/internal/test_runner_test.go
+++ b/internal/test_runner_test.go
@@ -64,7 +64,9 @@ func TestShouldFailIfAtLeastOneFailingTestIsRun(t *testing.T) {
 }
 
 func TestShouldLogTheGuidelineNameWhenRunningTheTest(t *testing.T) {
-	runner := NewTestRunner([]QualityGuideline{&PassingQualityGuideline{name: "TRG 1 - README test"}})
+	runner := NewTestRunner(
+		[]QualityGuideline{&PassingQualityGuideline{Guideline{name: "TRG 1 - README test"}}},
+	)
 	printerMock := &PrinterMock{}
 	runner.printer = printerMock
 
@@ -81,9 +83,11 @@ func TestShouldLogTheGuidelineNameWhenRunningTheTest(t *testing.T) {
 
 func TestShouldLogDescriptionOfGuidelineIfTheTestIsFailing(t *testing.T) {
 	failingGuideline := &FailingQualityGuideline{
-		name:                "TRG 3000 - ChuckNorris",
-		description:         "Every project should define counter measures against roundhouse kicks",
-		externalDescription: "https://en.wikipedia.org/wiki/Chuck_Norris",
+		Guideline{
+			name:                "TRG 3000 - ChuckNorris",
+			description:         "Every project should define counter measures against roundhouse kicks",
+			externalDescription: "https://en.wikipedia.org/wiki/Chuck_Norris",
+		},
 	}
 	runner := NewTestRunner([]QualityGuideline{failingGuideline})
 	printerMock := &PrinterMock{}
@@ -108,14 +112,18 @@ func TestShouldLogDescriptionOfGuidelineIfTheTestIsFailing(t *testing.T) {
 
 func TestShouldOnlyLogAdditionalDescriptionForFailingTests(t *testing.T) {
 	failingGuideline := &FailingQualityGuideline{
-		name:                "TRG 3000 - ChuckNorris",
-		description:         "Every project should define counter measures against roundhouse kicks",
-		externalDescription: "https://en.wikipedia.org/wiki/Chuck_Norris",
+		Guideline{
+			name:                "TRG 3000 - ChuckNorris",
+			description:         "Every project should define counter measures against roundhouse kicks",
+			externalDescription: "https://en.wikipedia.org/wiki/Chuck_Norris",
+		},
 	}
 	passingGuideline := &PassingQualityGuideline{
-		name:                "TRG 4711 - auto-pass",
-		description:         "automatically passing. result ignored",
-		externalDescription: "https://de.wikipedia.org/wiki//dev/null",
+		Guideline{
+			name:                "TRG 4711 - auto-pass",
+			description:         "automatically passing. result ignored",
+			externalDescription: "https://de.wikipedia.org/wiki//dev/null",
+		},
 	}
 	runner := NewTestRunner([]QualityGuideline{failingGuideline, passingGuideline})
 	printerMock := &PrinterMock{}

--- a/internal/types.go
+++ b/internal/types.go
@@ -19,15 +19,26 @@
 
 package txqualitychecks
 
-// QualityGuideline defines the QualityGuideline interface with its methods.
+// QualityGuideline represents the QualityGuideline to check as an interface.
+//
+// The interface provide information about Name, Description, ExternalDescription,
+// the Test and the IsOptional bool.
 type QualityGuideline interface {
+	// Name returns the Name to the QualityGuideline to test.
 	Name() string
+	// Description returns a brief description of the tested QualityGuideline.
 	Description() string
+	// ExternalDescription returns a URL to more information about the QualityGuideline.
 	ExternalDescription() string
+	// Test executes the test and returns QualityResult. If any error occurs it
+	// returns QualityResult.Passed false.
 	Test() *QualityResult
+	// IsOptional returns a bool it the test or QualityGuideline is optional or not.
 	IsOptional() bool
 }
 
+// QualityResult implements test result via Passed bool and in case of error a
+// ErrorDescription.
 type QualityResult struct {
 	Passed           bool
 	ErrorDescription string

--- a/internal/types.go
+++ b/internal/types.go
@@ -26,6 +26,7 @@ type QualityGuideline interface {
 	Description() string
 	ExternalDescription() string
 	Test() *QualityResult
+	IsOptional() bool
 }
 
 type QualityResult struct {


### PR DESCRIPTION
Implemented new method `IsOptional` in interface `QualityGuideline` to cover optional checks (aka `INSTALL.md` or `AUTHOR.md`(→ TRG 2.03)).

Added new feature to test if optional file 'INSTALL.md' exists. If the file does not exist, this test fails (for now) but not the test run itself (does not exit 1):

```shell
$ go run main.go checkLocal
Running local checks of eclipse-tractusx release guidelines
Testing Quality Guideline: TRG 1.01 - README.md
Testing Quality Guideline: TRG 1.02 - INSTALL.md
Failed! Test failed, but marked as optional. More infos: Did not find optional INSTALL.md file in current directory.
https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-2
Testing Quality Guideline: TRG 1.03 - CHANGELOG.md
```

Closes #10 