### PR TITLE
feat: add repo structure check

### DIFF
--- a/internal/globals.go
+++ b/internal/globals.go
@@ -27,5 +27,5 @@ var ReleaseGuidelines = []QualityGuideline{
 	NewChangelogExists(),
 	NewLeadingRepositoryDefined(),
 	NewDefaultBranch(),
-	NewRepoStructureExist(),
+	NewRepoStructureExists(),
 }

--- a/internal/repo_structure_exists.go
+++ b/internal/repo_structure_exists.go
@@ -17,15 +17,39 @@
  * SPDX-License-Identifier: Apache-2.0
  ******************************************************************************/
 
-package txqualitychecks
+ package txqualitychecks
 
-// ReleaseGuidelines defines a slice of QualityGuidelines the test_runner will
-// test.
-var ReleaseGuidelines = []QualityGuideline{
-	NewReadmeExists(),
-	NewInstallExists(),
-	NewChangelogExists(),
-	NewLeadingRepositoryDefined(),
-	NewDefaultBranch(),
-	NewRepoStructureExist(),
-}
+ import "os"
+ 
+ type RepoStructureExists struct {
+ }
+ 
+ func (c RepoStructureExists) IsOptional() bool {
+	 return false
+ }
+ 
+ func NewRepoStructureExists() *RepoStructureExists {
+	 return &RepoStructureExists{}
+ }
+ 
+ func (c RepoStructureExists) Name() string {
+	 return "TRG 2.03 - Repo structure"
+ }
+ 
+ func (c RepoStructureExists) Description() string {
+	 return "All repositories must follow specified files and folders structure."
+ }
+ 
+ func (c RepoStructureExists) ExternalDescription() string {
+	 return "https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-3"
+ }
+ 
+ func (c RepoStructureExists) Test() *QualityResult {
+	//  _, err := os.Stat("file or folder to be checked")
+ 
+	//  if err != nil {
+	// 	 return &QualityResult{ErrorDescription: "A file or folder is missing in the structure."}
+	//  }
+	 return &QualityResult{Passed: true}
+ }
+ 

--- a/internal/repo_structure_exists.go
+++ b/internal/repo_structure_exists.go
@@ -22,34 +22,31 @@ package txqualitychecks
 import (
 	"os"
 )
- 
- type RepoStructureExists struct {
- }
- 
- func (c RepoStructureExists) IsOptional() bool {
-	 return false
- }
- 
- func NewRepoStructureExists() *RepoStructureExists {
-	 return &RepoStructureExists{}
- }
- 
- func (c RepoStructureExists) Name() string {
-	 return "TRG 2.03 - Repo structure"
- }
- 
- func (c RepoStructureExists) Description() string {
-	 return "All repositories must follow specified files and folders structure."
- }
- 
- func (c RepoStructureExists) ExternalDescription() string {
-	 return "https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-3"
- }
- 
- func (c RepoStructureExists) Test() *QualityResult {
 
-	var missingMandatoryFiles []string
-	var missingOptionalFiles []string
+type RepoStructureExists struct {
+}
+
+func (c RepoStructureExists) IsOptional() bool {
+	return false
+}
+
+func NewRepoStructureExists() *RepoStructureExists {
+	return &RepoStructureExists{}
+}
+
+func (c RepoStructureExists) Name() string {
+	return "TRG 2.03 - Repo structure"
+}
+
+func (c RepoStructureExists) Description() string {
+	return "All repositories must follow specified files and folders structure."
+}
+
+func (c RepoStructureExists) ExternalDescription() string {
+	return "https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-3"
+}
+
+func (c RepoStructureExists) Test() *QualityResult {
 
 	// Slice containing required files and folders in the repo structure.
 	// Before modification make sure you align to TRG 2.03 guideline.
@@ -71,54 +68,48 @@ import (
 		"charts",
 	}
 
-	missingMandatoryFiles = checkMissingFiles(listOfMandatoryFilesToBeChecked)
-	missingOptionalFiles = checkMissingFiles(listOfOptionalFilesToBeChecked)	
+	missingMandatoryFiles := checkMissingFiles(listOfMandatoryFilesToBeChecked)
+	missingOptionalFiles := checkMissingFiles(listOfOptionalFilesToBeChecked)
 
-	optionalMessage := "Warning! The check detected following optional files missing: " 
-	mandatoryMassege := "The check detected following mandatory files missing: "
+	optionalMessage := "Warning! The check detected following optional files missing: "
+	mandatoryMassage := "The check detected following mandatory files missing: "
 
 	if len(missingOptionalFiles) > 0 {
-		optionalMessage = fmtMessage(optionalMessage, missingOptionalFiles)+"\n\t"
+		optionalMessage = fmtMessage(optionalMessage, missingOptionalFiles) + "\n\t"
 	}
 
 	if len(missingMandatoryFiles) > 0 {
-		mandatoryMassege = fmtMessage(mandatoryMassege, missingMandatoryFiles)
+		mandatoryMassage = fmtMessage(mandatoryMassage, missingMandatoryFiles)
 	}
 
-	if len(missingMandatoryFiles) > 0 && len(missingOptionalFiles) == 0 {
-		return &QualityResult{ErrorDescription: mandatoryMassege}
-
-	} else if len(missingMandatoryFiles) > 0 && len(missingOptionalFiles) > 0  {
-		return &QualityResult{ErrorDescription: optionalMessage + mandatoryMassege}
-		
-	} else if len(missingMandatoryFiles) == 0 && len(missingOptionalFiles) > 0 {
+	if len(missingMandatoryFiles) == 0 && len(missingOptionalFiles) > 0 {
 		return &QualityResult{ErrorDescription: optionalMessage, Passed: true}
+	} else if len(missingMandatoryFiles) > 0 || len(missingOptionalFiles) > 0 {
+		return &QualityResult{ErrorDescription: optionalMessage + mandatoryMassage}
 	}
 
 	return &QualityResult{Passed: true}
- }
- 
+}
 
- // Function to verify files existance. 
-//  Return missing ones.
- func checkMissingFiles(listOfFiles []string) []string {
+// Function to verify files existance.
+// Return missing ones.
+func checkMissingFiles(listOfFiles []string) []string {
 	var missingFiles []string
 
 	for _, file := range listOfFiles {
 
-		_, err := os.Stat(file)
-		if os.IsNotExist(err) {
+		if _, err := os.Stat(file); os.IsNotExist(err) {
 			missingFiles = append(missingFiles, file)
 		}
 	}
 	return missingFiles
- }
+}
 
- // Function to format output message containing missing files.
- func fmtMessage(startingMessage string, listOfFiles []string) string {
+// Function to format output message containing missing files.
+func fmtMessage(startingMessage string, listOfFiles []string) string {
 	message := startingMessage
-	for _,missingFile := range listOfFiles {
-		message += missingFile+" "
+	for _, missingFile := range listOfFiles {
+		message += missingFile + " "
 	}
 	return message
- }
+}

--- a/internal/repo_structure_exists.go
+++ b/internal/repo_structure_exists.go
@@ -72,20 +72,20 @@ func (c RepoStructureExists) Test() *QualityResult {
 	missingOptionalFiles := checkMissingFiles(listOfOptionalFilesToBeChecked)
 
 	optionalMessage := "Warning! The check detected following optional files missing: "
-	mandatoryMassage := "The check detected following mandatory files missing: "
+	mandatoryMessage := "The check detected following mandatory files missing: "
 
 	if len(missingOptionalFiles) > 0 {
 		optionalMessage = fmtMessage(optionalMessage, missingOptionalFiles) + "\n\t"
 	}
 
 	if len(missingMandatoryFiles) > 0 {
-		mandatoryMassage = fmtMessage(mandatoryMassage, missingMandatoryFiles)
+		mandatoryMessage = fmtMessage(mandatoryMessage, missingMandatoryFiles)
 	}
 
 	if len(missingMandatoryFiles) == 0 && len(missingOptionalFiles) > 0 {
 		return &QualityResult{ErrorDescription: optionalMessage, Passed: true}
 	} else if len(missingMandatoryFiles) > 0 || len(missingOptionalFiles) > 0 {
-		return &QualityResult{ErrorDescription: optionalMessage + mandatoryMassage}
+		return &QualityResult{ErrorDescription: optionalMessage + mandatoryMessage}
 	}
 
 	return &QualityResult{Passed: true}

--- a/internal/repo_structure_exists_test.go
+++ b/internal/repo_structure_exists_test.go
@@ -24,48 +24,50 @@ import (
 	"testing"
 )
 
-func TestShouldPassIfRepoStructureExists(t *testing.T) {
+var listOfFilesToBeCreated []string = []string{
+	"CODE_OF_CONDUCT.md",
+	"CONTRIBUTING.md",
+	"DEPENDENCIES",
+	"LICENSE",
+	"NOTICE.md",
+	"README.md",
+	"SECURITY.md",
+}
 
-	listOfFilesToBeCreated := []string{
-		"AUTHORS.md",
-		"CODE_OF_CONDUCT.md",
-		"CONTRIBUTING.md",
-		"DEPENDENCIES",
-		"LICENSE",
-		"NOTICE.md",
-		"README.md",
-		"INSTALL.md",
-		"SECURITY.md",
-	}
+var listOfDirsToBeCreated []string = []string{
+	"docs",
+	"charts",
+}
 
-	listOfDirsToBeCreated := []string{
-		"docs",
-		"charts",
-	}
+func TestShouldPassIfRepoStructureExistsWithoutOptional(t *testing.T) {
 
-	for _,file := range listOfFilesToBeCreated {
-		os.Create(file)
-		toBeRemoved := file
-		defer func() {
-			_ = os.Remove(toBeRemoved)
-		}()
-	}
-
-	for _,file := range listOfDirsToBeCreated {
-		os.Mkdir(file, 0750)
-		toBeRemoved := file
-		defer func() {
-			_ = os.Remove(toBeRemoved)
-		}()
-	}
+	createFiles(listOfFilesToBeCreated)
+	createDirs(listOfDirsToBeCreated)
 
 	repostructureTest := NewRepoStructureExists()
-
 	result := repostructureTest.Test()
+	cleanFiles(append(listOfFilesToBeCreated, listOfDirsToBeCreated...))
 
 	if !result.Passed {
-		t.Errorf("Structure exists, but test still fails.")
+		t.Errorf("Structure exists with optional files, but test still fails.")
 	}
+}
+
+func TestShouldPassIfRepoStructureExistsWithOptional(t *testing.T) {
+
+	listOfFilesToBeCreated = append(listOfFilesToBeCreated, []string{"INSTALL.md", "AUTHORS.md"}...)
+
+	createFiles(listOfFilesToBeCreated)
+	createDirs(listOfDirsToBeCreated)
+
+	repostructureTest := NewRepoStructureExists()
+	result := repostructureTest.Test()
+	cleanFiles(append(listOfFilesToBeCreated, listOfDirsToBeCreated...))
+
+	if !result.Passed {
+		t.Errorf("Structure exists without optional files, but test still fails.")
+	}
+
 }
 
 func TestShouldFailIfRepoStructureIsMissing(t *testing.T) {
@@ -75,5 +77,24 @@ func TestShouldFailIfRepoStructureIsMissing(t *testing.T) {
 
 	if result.Passed {
 		t.Errorf("RepoStructureExist should fail if repo structure exists.")
+	}
+}
+
+func createFiles(files []string) {
+	for _, file := range files {
+		os.Create(file)
+	}
+}
+
+func createDirs(dirs []string) {
+	for _, dir := range dirs {
+		os.Mkdir(dir, 0750)
+	}
+}
+
+func cleanFiles(files []string) {
+
+	for _, file := range files {
+		os.Remove(file)
 	}
 }

--- a/internal/repo_structure_exists_test.go
+++ b/internal/repo_structure_exists_test.go
@@ -19,13 +19,11 @@
 
 package txqualitychecks
 
-// ReleaseGuidelines defines a slice of QualityGuidelines the test_runner will
-// test.
-var ReleaseGuidelines = []QualityGuideline{
-	NewReadmeExists(),
-	NewInstallExists(),
-	NewChangelogExists(),
-	NewLeadingRepositoryDefined(),
-	NewDefaultBranch(),
-	NewRepoStructureExist(),
+import (
+	"os"
+	"testing"
+)
+
+func TestShouldPassIfRepoStructureExists(t *testing.T) {
+
 }

--- a/internal/repo_structure_exists_test.go
+++ b/internal/repo_structure_exists_test.go
@@ -26,4 +26,54 @@ import (
 
 func TestShouldPassIfRepoStructureExists(t *testing.T) {
 
+	listOfFilesToBeCreated := []string{
+		"AUTHORS.md",
+		"CODE_OF_CONDUCT.md",
+		"CONTRIBUTING.md",
+		"DEPENDENCIES",
+		"LICENSE",
+		"NOTICE.md",
+		"README.md",
+		"INSTALL.md",
+		"SECURITY.md",
+	}
+
+	listOfDirsToBeCreated := []string{
+		"docs",
+		"charts",
+	}
+
+	for _,file := range listOfFilesToBeCreated {
+		os.Create(file)
+		toBeRemoved := file
+		defer func() {
+			_ = os.Remove(toBeRemoved)
+		}()
+	}
+
+	for _,file := range listOfDirsToBeCreated {
+		os.Mkdir(file, 0750)
+		toBeRemoved := file
+		defer func() {
+			_ = os.Remove(toBeRemoved)
+		}()
+	}
+
+	repostructureTest := NewRepoStructureExists()
+
+	result := repostructureTest.Test()
+
+	if !result.Passed {
+		t.Errorf("Structure exists, but test still fails.")
+	}
+}
+
+func TestShouldFailIfRepoStructureIsMissing(t *testing.T) {
+	repostructureTest := NewRepoStructureExists()
+
+	result := repostructureTest.Test()
+
+	if result.Passed {
+		t.Errorf("RepoStructureExist should fail if repo structure exists.")
+	}
 }

--- a/internal/test_runner.go
+++ b/internal/test_runner.go
@@ -49,6 +49,11 @@ func (runner *GuidelineTestRunner) Run() error {
 				fmt.Sprintf("Failed! Guideline description: %s\n\t%s\n\tMore infos: %s",
 					guideline.Description(), result.ErrorDescription, guideline.ExternalDescription()),
 			)
+		} else if result.Passed && result.ErrorDescription != "" {
+			runner.printer.Print(
+				fmt.Sprintf("Warning! Guideline description: %s\n\t%s\n\tMore infos: %s",
+					guideline.Description(), result.ErrorDescription, guideline.ExternalDescription()),
+			)
 		}
 
 		allPassed = allPassed && (result.Passed || guideline.IsOptional())


### PR DESCRIPTION
---
title: 'feat: implementation of repo structure check'
---

## Description

PR introduces a new tractusx-quality-check feature validating repository structure as per [TRG 2.03 guideline](https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-3) .
 
## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [V] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [V] Copyright and license header are present on all affected files

### Additional information

- To request a review, check out [who's involved](https://projects.eclipse.org/projects/automotive.tractusx/who) to see a list of contributors and committers
- Use the [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) if you are unsure, who to contact, or if want to engage in a general discussion
- Check out our guide on [how to contribute](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute)
- Check out our [Release Guidelines](https://eclipse-tractusx.github.io/docs/release)
- Check out the [Eclipse Foundation contribution guidelines](https://www.eclipse.org/projects/handbook/#contributing)
