### PR TITLE
fix: repo structure check requires docs and charts dirs only for leading repos now + new package 'repo'

### DIFF
--- a/internal/repo_structure_exists.go
+++ b/internal/repo_structure_exists.go
@@ -20,6 +20,7 @@
 package txqualitychecks
 
 import (
+	"fmt"
 	"os"
 )
 
@@ -71,21 +72,16 @@ func (c RepoStructureExists) Test() *QualityResult {
 	missingMandatoryFiles := checkMissingFiles(listOfMandatoryFilesToBeChecked)
 	missingOptionalFiles := checkMissingFiles(listOfOptionalFilesToBeChecked)
 
-	optionalMessage := "Warning! The check detected following optional files missing: "
+	optionalMessage := "The check detected following optional files missing: "
 	mandatoryMessage := "The check detected following mandatory files missing: "
 
 	if len(missingOptionalFiles) > 0 {
-		optionalMessage = fmtMessage(optionalMessage, missingOptionalFiles) + "\n\t"
+		fmt.Printf("Warning! Guideline description: %s\n\t%s\n\tMore infos: %s\n",
+			c.Description(), fmtMessage(optionalMessage, missingOptionalFiles), c.ExternalDescription())
 	}
 
 	if len(missingMandatoryFiles) > 0 {
-		mandatoryMessage = fmtMessage(mandatoryMessage, missingMandatoryFiles)
-	}
-
-	if len(missingMandatoryFiles) == 0 && len(missingOptionalFiles) > 0 {
-		return &QualityResult{ErrorDescription: optionalMessage, Passed: true}
-	} else if len(missingMandatoryFiles) > 0 || len(missingOptionalFiles) > 0 {
-		return &QualityResult{ErrorDescription: optionalMessage + mandatoryMessage}
+		return &QualityResult{ErrorDescription: fmtMessage(mandatoryMessage, missingMandatoryFiles)}
 	}
 
 	return &QualityResult{Passed: true}

--- a/internal/repo_structure_exists.go
+++ b/internal/repo_structure_exists.go
@@ -21,6 +21,7 @@ package txqualitychecks
 
 import (
 	"fmt"
+	"github.com/eclipse-tractusx/tractusx-quality-checks/pkg/product"
 	"os"
 )
 
@@ -65,8 +66,12 @@ func (c RepoStructureExists) Test() *QualityResult {
 		"NOTICE.md",
 		"README.md",
 		"SECURITY.md",
-		"docs",
-		"charts",
+	}
+
+	mandatoryForLeadingRepo := []string{"docs", "charts"}
+
+	if product.IsLeadingRepo() {
+		listOfMandatoryFilesToBeChecked = append(listOfMandatoryFilesToBeChecked, mandatoryForLeadingRepo...)
 	}
 
 	missingMandatoryFiles := checkMissingFiles(listOfMandatoryFilesToBeChecked)

--- a/internal/repo_structure_exists_test.go
+++ b/internal/repo_structure_exists_test.go
@@ -39,11 +39,16 @@ var listOfDirsToBeCreated []string = []string{
 	"charts",
 }
 
+const metadataTestFile = "../pkg/product/test/metadata_test_template.yaml"
+
 func TestShouldPassIfRepoStructureExistsWithoutOptional(t *testing.T) {
+	
+	setEnv(t)
+	defer os.Remove(".tractusx")
 
 	createFiles(listOfFilesToBeCreated)
 	createDirs(listOfDirsToBeCreated)
-
+	
 	repostructureTest := NewRepoStructureExists()
 	result := repostructureTest.Test()
 	cleanFiles(append(listOfFilesToBeCreated, listOfDirsToBeCreated...))
@@ -54,6 +59,9 @@ func TestShouldPassIfRepoStructureExistsWithoutOptional(t *testing.T) {
 }
 
 func TestShouldPassIfRepoStructureExistsWithOptional(t *testing.T) {
+
+	setEnv(t)
+	defer os.Remove(".tractusx")
 
 	listOfFilesToBeCreated = append(listOfFilesToBeCreated, []string{"INSTALL.md", "AUTHORS.md"}...)
 
@@ -71,6 +79,10 @@ func TestShouldPassIfRepoStructureExistsWithOptional(t *testing.T) {
 }
 
 func TestShouldFailIfRepoStructureIsMissing(t *testing.T) {
+
+	setEnv(t)
+	defer os.Remove(".tractusx")
+
 	repostructureTest := NewRepoStructureExists()
 
 	result := repostructureTest.Test()
@@ -96,5 +108,22 @@ func cleanFiles(files []string) {
 
 	for _, file := range files {
 		os.Remove(file)
+	}
+}
+
+func setEnv(t *testing.T) {
+	copyTemplateFileTo(".tractusx", t)
+	os.Setenv("GITHUB_REPOSITORY", "eclipse-tractusx/sig-infra")
+	os.Setenv("GITHUB_REPOSITORY_OWNER", "tester")
+}
+
+func copyTemplateFileTo(path string, t *testing.T) {
+	templateFile, err := os.ReadFile(metadataTestFile)
+	if err != nil {
+		t.Errorf("Could not read template file necessary for this test")
+	}
+	err = os.WriteFile(path, templateFile, 0644)
+	if err != nil {
+		t.Errorf("Could not copy template file to designated path")
 	}
 }

--- a/internal/repo_structure_exists_test.go
+++ b/internal/repo_structure_exists_test.go
@@ -42,13 +42,13 @@ var listOfDirsToBeCreated []string = []string{
 const metadataTestFile = "../pkg/product/test/metadata_test_template.yaml"
 
 func TestShouldPassIfRepoStructureExistsWithoutOptional(t *testing.T) {
-	
+
 	setEnv(t)
 	defer os.Remove(".tractusx")
 
 	createFiles(listOfFilesToBeCreated)
 	createDirs(listOfDirsToBeCreated)
-	
+
 	repostructureTest := NewRepoStructureExists()
 	result := repostructureTest.Test()
 	cleanFiles(append(listOfFilesToBeCreated, listOfDirsToBeCreated...))

--- a/internal/test_runner.go
+++ b/internal/test_runner.go
@@ -49,7 +49,7 @@ func (runner *GuidelineTestRunner) Run() error {
 				fmt.Sprintf("Failed! Guideline description: %s\n\t%s\n\tMore infos: %s",
 					guideline.Description(), result.ErrorDescription, guideline.ExternalDescription()),
 			)
-		} 
+		}
 
 		allPassed = allPassed && (result.Passed || guideline.IsOptional())
 	}

--- a/internal/test_runner.go
+++ b/internal/test_runner.go
@@ -49,12 +49,7 @@ func (runner *GuidelineTestRunner) Run() error {
 				fmt.Sprintf("Failed! Guideline description: %s\n\t%s\n\tMore infos: %s",
 					guideline.Description(), result.ErrorDescription, guideline.ExternalDescription()),
 			)
-		} else if result.Passed && result.ErrorDescription != "" {
-			runner.printer.Print(
-				fmt.Sprintf("Warning! Guideline description: %s\n\t%s\n\tMore infos: %s",
-					guideline.Description(), result.ErrorDescription, guideline.ExternalDescription()),
-			)
-		}
+		} 
 
 		allPassed = allPassed && (result.Passed || guideline.IsOptional())
 	}

--- a/pkg/product/metadata.go
+++ b/pkg/product/metadata.go
@@ -21,9 +21,9 @@ package product
 
 import (
 	"fmt"
-	"os"
-
+	"github.com/eclipse-tractusx/tractusx-quality-checks/pkg/repo"
 	"gopkg.in/yaml.v3"
+	"os"
 )
 
 const MetadataFilename = ".tractusx"
@@ -72,4 +72,17 @@ func MetadataFromLocalFile() (*Metadata, error) {
 	}
 
 	return file, nil
+}
+
+func IsLeadingRepo() bool {
+
+	metadata, err := MetadataFromLocalFile()
+	repoInfo := repo.GetRepoBaseInfo()
+	fullRepoName := "https://github.com/eclipse-tractusx/" + (*repoInfo).Reponame
+
+	if err != nil || metadata.LeadingRepository != fullRepoName {
+		return false
+	}
+
+	return true
 }

--- a/pkg/product/metadata_test.go
+++ b/pkg/product/metadata_test.go
@@ -69,6 +69,29 @@ func TestShouldReadProductMetadataFromDefaultFile(t *testing.T) {
 	}
 }
 
+func TestShouldPassIsLeadingRepoValidEnvVariable(t *testing.T) {
+	copyTemplateFileTo(".tractusx", t)
+	defer os.Remove(".tractusx")
+	os.Setenv("GITHUB_REPOSITORY", "eclipse-tractusx/sig-infra")
+	os.Setenv("GITHUB_REPOSITORY_OWNER", "tester")
+
+	if !IsLeadingRepo() {
+		t.Errorf("Test should pass, but $GITHUB_REPOSITORY is not equal leadingRepo from .tractusx")
+	}
+
+}
+
+func TestShouldFailIsLeadingRepoFakeEnvVariable(t *testing.T) {
+	copyTemplateFileTo(".tractusx", t)
+	defer os.Remove(".tractusx")
+	os.Setenv("GITHUB_REPOSITORY", "repo/fake_reponame")
+	os.Setenv("GITHUB_REPOSITORY_OWNER", "tester")
+
+	if IsLeadingRepo() {
+		t.Errorf("Repo shouldn't be identified as leading one, there is fake env variable $GITHUB_REPOSITORY.")
+	}
+}
+
 func copyTemplateFileTo(path string, t *testing.T) {
 	templateFile, err := os.ReadFile(metadataTestFile)
 	if err != nil {

--- a/pkg/repo/repoinfo.go
+++ b/pkg/repo/repoinfo.go
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package repo
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-ini/ini"
+	"github.com/google/go-github/v50/github"
+	"os"
+	"strings"
+)
+
+// RepoInfo struct provides required information to query GitHub API.
+// RepoInfo.local shall be true, when running check locally.
+type RepoInfo struct {
+	Owner    string
+	Reponame string
+}
+
+// getRepoBaseInfo returns RepoInfo as pointer. Func determines according to
+// available environment variables if running locally or as part of a GitHub
+// Action/Workflow/Check.
+func GetRepoBaseInfo() *RepoInfo {
+	const (
+		BASEURL = "https://github.com/"
+		SSHBASE = "git@github.com:"
+		SECTION = `remote "origin"`
+		SUFFIX  = ".git"
+	)
+
+	if os.Getenv("GITHUB_REPOSITORY") != "" && os.Getenv("GITHUB_REPOSITORY_OWNER") != "" {
+		// env variable is available when executed as GH Action/Workflow/Check
+		result := RepoInfo{
+			Owner:    os.Getenv("GITHUB_REPOSITORY_OWNER"),
+			Reponame: strings.Split(os.Getenv("GITHUB_REPOSITORY"), "/")[1],
+		}
+
+		return &result
+	}
+
+	// Parse local git configuration when executing locally
+	cfg, err := ini.Load(".git/config")
+	if err != nil {
+		fmt.Printf("Failed to read file: %v", err)
+	}
+
+	url := cfg.Section(SECTION).Key("url").String()
+
+	var repoSplitInfo []string
+	if strings.Contains(url, BASEURL) {
+		repoSplitInfo = strings.Split(strings.TrimSuffix(strings.TrimPrefix(url, BASEURL), SUFFIX), "/")
+	} else if strings.Contains(url, SSHBASE) {
+		repoSplitInfo = strings.Split(strings.TrimSuffix(strings.TrimPrefix(url, SSHBASE), SUFFIX), "/")
+	}
+
+	result := RepoInfo{
+		Owner:    repoSplitInfo[0],
+		Reponame: repoSplitInfo[1],
+	}
+
+	return &result
+}
+
+// getRepoInfo returns *github.Repository object and error. If GitHub API call
+// failed, an error is returned.
+func GetRepoMetadata(repo *RepoInfo) *github.Repository {
+	ctx := context.Background()
+	client := *github.NewClient(nil)
+
+	repoInfo, _, err := client.Repositories.Get(ctx, repo.Owner, repo.Reponame)
+	if err != nil {
+		fmt.Printf("Error querying GitHub API:\n%v\n", err)
+	}
+
+	return repoInfo
+}


### PR DESCRIPTION
## Description

1. The fix adds verification of the source repository whether it is a leading repository. Based on that includes or not 'docs' and 'charts' dirs to mandatory check. 
2. Implementation also incorporates new package 'repo' for basic repository metadata, making the code which was previously contained in the default branch check reusable to other components.
3. Finally it refines subject check code from having another condition in the test runner for a case where test should pass with optional information. 

updates https://github.com/eclipse-tractusx/sig-infra/issues/93
updates https://github.com/eclipse-tractusx/sig-infra/issues/151
updates https://github.com/eclipse-tractusx/tractusx-quality-checks/issues/20

Fixes #20

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [V] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [V] Copyright and license header are present on all affected files

### Additional information

- To request a review, check out [who's involved](https://projects.eclipse.org/projects/automotive.tractusx/who) to see a list of contributors and committers
- Use the [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) if you are unsure, who to contact, or if want to engage in a general discussion
- Check out our guide on [how to contribute](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute)
- Check out our [Release Guidelines](https://eclipse-tractusx.github.io/docs/release)
- Check out the [Eclipse Foundation contribution guidelines](https://www.eclipse.org/projects/handbook/#contributing)
