### PR TITLE
chore: update repository metadata

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -19,5 +19,9 @@
 ---
 
 product: "tractusx-quality-checks"
-leadingRepository: "https://github.com/eclipse-tractusx/tractusx-quality-checks"
-repositories: []
+leadingRepository: "https://github.com/eclipse-tractusx/sig-infra"
+repositories:
+    - "https://github.com/eclipse-tractusx/sig-infra"
+    - "https://github.com/eclipse-tractusx/tractusx-quality-checks"
+    - "https://github.com/eclipse-tractusx/charts"
+]


### PR DESCRIPTION
## Description

This PR updates the `.tractusx` repository metadata file. 
The updated metadata does declare [eclipse-tractusx/sig-infra](https://github.com/eclipse-tractusx/sig-infra) as leading repository and also points to other repositories related to `sig-infra`.

The leading repository is changed, so the quality checks workflow does not treat this repository like a product repository.
Currently the workflow is failing, since we do not provide a `/docs` and `/charts` folder. 
While `/docs` at least has a chance to be created in near future, `/charts` will most likely never be present.

We could also think of other ways to make the check a bit more "clever". Maybe introducing repo types (product, leading, docs, helper, etc.) or introduce an `--ignore` flag to our checks command.