### PR TITLE
feat(action): run checks via pre-built binary

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -21,7 +21,12 @@
 product: "tractusx-quality-checks"
 leadingRepository: "https://github.com/eclipse-tractusx/sig-infra"
 repositories:
-    - "https://github.com/eclipse-tractusx/sig-infra"
-    - "https://github.com/eclipse-tractusx/tractusx-quality-checks"
-    - "https://github.com/eclipse-tractusx/charts"
-]
+    - name: "Tractus-X quality checks"
+      usage: "automated release guidelines checks"
+      url: "https://github.com/eclipse-tractusx/tractusx-quality-checks"
+    - name: "SIG Infra"
+      usage: "Special interest group for infra topics (repos, workflows, consortium infra, etc.)"
+      url: "https://github.com/eclipse-tractusx/sig-infra"
+    - name: "Charts"
+      usage: "Acts as central Helm Chart repository"
+      url: "https://github.com/eclipse-tractusx/charts"

--- a/action.yaml
+++ b/action.yaml
@@ -19,14 +19,24 @@
 
 name: "eclipse-tractusx-quality-checks"
 description: "Run quality checks based on the release guidelines"
+inputs:
+  version:
+    description: The version of the quality checks release to use
+    required: true
+    default: "0.3.0"
 
 runs:
   using: composite
   steps:
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version-file: "go.mod"
-    - run: go run main.go checkLocal
+    - name: Download quality checks binary
+      run: curl -OL https://github.com/eclipse-tractusx/tractusx-quality-checks/releases/download/v${{ inputs.version }}/tractusx-quality-checks-${{ inputs.version }}
+      shell: bash
+
+    - name: Make binary executable
+      run: chmod +x ./tractusx-quality-checks-${{ inputs.version }}
+      shell: bash
+
+    - name: Run quality checks
+      run: ./tractusx-quality-checks-${{ inputs.version }} checkLocal
       shell: bash
 


### PR DESCRIPTION
## Description

This PR adjusts the quality-check action to run the quality checks on a pre-built binary, that is downloaded from a GitHub release in this repository.
The version to install is configurable via action input and currently defaults to our last release.

Closes #21 