### PR TITLE
chore: update workflow trigger for pull request

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -27,7 +27,7 @@ on:
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
+    types: [edited, opened, reopened, synchronize]
 
   workflow_dispatch:
 


### PR DESCRIPTION
If an invalid PR title has been selected while creating the PR, the PR lint workflow will complain about it and the release drafter has not labeled the PR.

After editing the PR title to macht the linter the release drafter isn't triggered again to label the PR. Added _edited_ type to trigger release drafter after editing the PR title.