### PR TITLE
fix: auto-pass default branch check on forks

### DIFF
--- a/internal/repo/default_branch.go
+++ b/internal/repo/default_branch.go
@@ -27,6 +27,10 @@ import (
 type defaultBranch struct {
 }
 
+func NewDefaultBranch() txqualitychecks.QualityGuideline {
+	return &defaultBranch{}
+}
+
 func (d defaultBranch) Name() string {
 	return "TRG 2.01 - Default Branch"
 }
@@ -40,13 +44,15 @@ func (d defaultBranch) ExternalDescription() string {
 }
 
 func (d defaultBranch) Test() *txqualitychecks.QualityResult {
-	repoinfo := repo.GetRepoMetadata(repo.GetRepoBaseInfo())
+	repoInfo := repo.GetRepoMetadata(repo.GetRepoBaseInfo())
 
-	if *repoinfo.Fork {
-		return &txqualitychecks.QualityResult{Passed: false, ErrorDescription: "Check determined running on a fork."}
+	if *repoInfo.Fork {
+		// There is no need to enforce default branches on forks
+		// Since all the other checks should be executable on forks, we cannot let this single check break a workflow
+		return &txqualitychecks.QualityResult{Passed: true}
 	}
 
-	if *repoinfo.DefaultBranch != "main" {
+	if *repoInfo.DefaultBranch != "main" {
 		return &txqualitychecks.QualityResult{
 			Passed:           false,
 			ErrorDescription: "Default branch not set to 'main'.",
@@ -58,8 +64,4 @@ func (d defaultBranch) Test() *txqualitychecks.QualityResult {
 
 func (d defaultBranch) IsOptional() bool {
 	return false
-}
-
-func NewDefaultBranch() txqualitychecks.QualityGuideline {
-	return &defaultBranch{}
 }

--- a/pkg/repo/repoinfo.go
+++ b/pkg/repo/repoinfo.go
@@ -22,22 +22,23 @@ package repo
 import (
 	"context"
 	"fmt"
-	"github.com/go-ini/ini"
-	"github.com/google/go-github/v50/github"
 	"os"
 	"strings"
+
+	"github.com/go-ini/ini"
+	"github.com/google/go-github/v50/github"
 )
 
-// RepoInfo struct provides required information to query GitHub API.
-// RepoInfo.local shall be true, when running check locally.
+// RepoInfo provides basic infor
 type RepoInfo struct {
 	Owner    string
 	Reponame string
 }
 
-// getRepoBaseInfo returns RepoInfo as pointer. Func determines according to
-// available environment variables if running locally or as part of a GitHub
-// Action/Workflow/Check.
+// GetRepoBaseInfo gathers information about repo owner and name.
+// It leverages environment variables typically available in GitHub workflows.
+// As fallback option, the local git config (.git/config) file is used.
+// Results are returned as *RepoInfo
 func GetRepoBaseInfo() *RepoInfo {
 	const (
 		BASEURL = "https://github.com/"


### PR DESCRIPTION
## Description

This PR changes the behavior of the default branch check.

__Old behavior:__ Automatically fail, when running on a fork

__New behavior:__ Automatically pass, when running on a fork

__Reason:__ We do not need (and want) to enforce any repo settings on repositories, that contributions are made from.
This could interfere with development processes, without any benefit to the contribution itself.
Instead, it leads to failing quality checks, without an available workaround. 
Automatically passing the default branch check on forks does not change the quality of contributions and also does not interfere with outside repo settings

Fixes #34 
