### PR TITLE
fix: correct temurin docker image name for base image check

### DIFF
--- a/internal/container/allowed_base_image_check.go
+++ b/internal/container/allowed_base_image_check.go
@@ -27,7 +27,7 @@ import (
 )
 
 var baseImageAllowList = []string{
-	"eclipse/temurin",
+	"eclipse-temurin",
 	"nginxinc/nginx-unprivileged",
 	"mcr.microsoft.com/dotnet/runtime",
 	"mcr.microsoft.com/dotnet/aspnet",

--- a/internal/container/allowed_base_image_check_test.go
+++ b/internal/container/allowed_base_image_check_test.go
@@ -47,7 +47,7 @@ func TestShouldFailIfDockerfileWithUnapprovedBaseImagePresent(t *testing.T) {
 }
 
 func TestShouldPassIfTemurinIsUsedAsBaseImage(t *testing.T) {
-	file := newDockerfile().appendCommand("FROM eclipse/temurin:17")
+	file := newDockerfile().appendCommand("FROM eclipse-temurin:17")
 	_ = file.writeTo("./")
 	defer os.Remove(file.filename)
 
@@ -60,7 +60,7 @@ func TestShouldNotFailIfOnlyBuildLayerDeviatesFromTemurin(t *testing.T) {
 	file := newDockerfile().
 		appendCommand("FROM amazoncorretto:8 as builder").
 		appendCommand("COPY . .").
-		appendCommand("FROM eclipse/temurin:17")
+		appendCommand("FROM eclipse-temurin:17")
 	_ = file.writeTo("./")
 	defer os.Remove(file.filename)
 


### PR DESCRIPTION
## Description

Using the correct image name for Eclipse Temurin and fixing tests that worked on wrong assumptions

related to #36 