### PR TITLE
fix: multiple dependencies files accepted by repo structure check

### DIFF
--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -59,7 +59,7 @@ func CheckMissingFiles(listOfFiles []string) []string {
 	return missingFiles
 }
 
-func findPrefixedFiles(dir string, prefix string) []string {
+func FindPrefixedFiles(dir string, prefix string) []string {
 	var foundFiles []string
 	filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
 		if !info.IsDir() && strings.Contains(info.Name(), prefix) {

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -20,8 +20,11 @@
 package filesystem
 
 import (
+	"io/fs"
 	"log"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 func CreateFiles(files []string) {
@@ -54,4 +57,15 @@ func CheckMissingFiles(listOfFiles []string) []string {
 		}
 	}
 	return missingFiles
+}
+
+func findPrefixedFiles(dir string, prefix string) []string {
+	var foundFiles []string
+	filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
+		if !info.IsDir() && strings.Contains(info.Name(), prefix) {
+			foundFiles = append(foundFiles, path)
+		}
+		return nil
+	})
+	return foundFiles
 }

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -62,7 +62,7 @@ func CheckMissingFiles(listOfFiles []string) []string {
 func FindPrefixedFiles(dir string, prefix string) []string {
 	var foundFiles []string
 	filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
-		if !info.IsDir() && strings.Contains(info.Name(), prefix) {
+		if !info.IsDir() && strings.HasPrefix(info.Name(), prefix) {
 			foundFiles = append(foundFiles, path)
 		}
 		return nil

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -20,10 +20,8 @@
 package filesystem
 
 import (
-	"io/fs"
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
 )
 
@@ -61,11 +59,14 @@ func CheckMissingFiles(listOfFiles []string) []string {
 
 func FindPrefixedFiles(dir string, prefix string) []string {
 	var foundFiles []string
-	filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
-		if !info.IsDir() && strings.HasPrefix(info.Name(), prefix) {
-			foundFiles = append(foundFiles, path)
-		}
+	fs, err := os.ReadDir(dir)
+	if err != nil {
 		return nil
-	})
+	}
+	for _, f := range fs {
+		if !f.IsDir() && strings.HasPrefix(f.Name(), prefix) {
+			foundFiles = append(foundFiles, f.Name())
+		}
+	}
 	return foundFiles
 }

--- a/pkg/repo/repo_structure_exists.go
+++ b/pkg/repo/repo_structure_exists.go
@@ -54,7 +54,6 @@ func (c RepoStructureExists) ExternalDescription() string {
 }
 
 func (c RepoStructureExists) Test() *tractusx.QualityResult {
-	dir := "."
 	// Slices containing required files and folders in the repo structure.
 	// Before modification make sure you align to TRG 2.03 guideline.
 	listOfOptionalFilesToBeChecked := []string{
@@ -80,7 +79,7 @@ func (c RepoStructureExists) Test() *tractusx.QualityResult {
 
 	missingMandatoryFiles := filesystem.CheckMissingFiles(listOfMandatoryFilesToBeChecked)
 	missingOptionalFiles := filesystem.CheckMissingFiles(listOfOptionalFilesToBeChecked)
-	if dependencyFiles := filesystem.FindPrefixedFiles(dir, "DEPENDENCIES"); dependencyFiles == nil {
+	if dependencyFiles := filesystem.FindPrefixedFiles(c.baseDir, "DEPENDENCIES"); dependencyFiles == nil {
 		missingMandatoryFiles = append(missingMandatoryFiles, "DEPENDENCIES")
 	}
 

--- a/pkg/repo/repo_structure_exists.go
+++ b/pkg/repo/repo_structure_exists.go
@@ -54,6 +54,7 @@ func (c RepoStructureExists) ExternalDescription() string {
 }
 
 func (c RepoStructureExists) Test() *tractusx.QualityResult {
+	dir := "."
 	// Slices containing required files and folders in the repo structure.
 	// Before modification make sure you align to TRG 2.03 guideline.
 	listOfOptionalFilesToBeChecked := []string{
@@ -64,7 +65,6 @@ func (c RepoStructureExists) Test() *tractusx.QualityResult {
 	listOfMandatoryFilesToBeChecked := []string{
 		path.Join(c.baseDir, "CODE_OF_CONDUCT.md"),
 		path.Join(c.baseDir, "CONTRIBUTING.md"),
-		path.Join(c.baseDir, "DEPENDENCIES"),
 		path.Join(c.baseDir, "LICENSE"),
 		path.Join(c.baseDir, "NOTICE.md"),
 		path.Join(c.baseDir, "README.md"),
@@ -80,6 +80,9 @@ func (c RepoStructureExists) Test() *tractusx.QualityResult {
 
 	missingMandatoryFiles := filesystem.CheckMissingFiles(listOfMandatoryFilesToBeChecked)
 	missingOptionalFiles := filesystem.CheckMissingFiles(listOfOptionalFilesToBeChecked)
+	if dependencyFiles := filesystem.FindPrefixedFiles(dir, "DEPENDENCIES"); dependencyFiles == nil {
+		missingMandatoryFiles = append(missingMandatoryFiles, "DEPENDENCIES")
+	}
 
 	if len(missingOptionalFiles) > 0 {
 		printer.LogWarning(

--- a/pkg/repo/repo_structure_exists_test.go
+++ b/pkg/repo/repo_structure_exists_test.go
@@ -29,11 +29,11 @@ import (
 var listOfFilesToBeCreated = []string{
 	"CODE_OF_CONDUCT.md",
 	"CONTRIBUTING.md",
-	"DEPENDENCIES",
 	"LICENSE",
 	"NOTICE.md",
 	"README.md",
 	"SECURITY.md",
+	"DEPENDENCIES",
 }
 
 var listOfDirsToBeCreated = []string{
@@ -88,6 +88,23 @@ func TestShouldFailIfRepoStructureIsMissing(t *testing.T) {
 
 	if result.Passed {
 		t.Errorf("RepoStructureExist should fail if repo structure exists.")
+	}
+}
+
+func TestShouldPassWithMultipleDependenciesFiles(t *testing.T) {
+	setEnv(t)
+	defer os.Remove(".tractusx")
+
+	newListOfFilesToBeCreated := append(listOfFilesToBeCreated[:len(listOfFilesToBeCreated)-1], []string{"DEPENDENCIES_FRONTEND", "DEPENDENCIES_BACKEND"}...)
+	filesystem.CreateFiles(newListOfFilesToBeCreated)
+	filesystem.CreateDirs(listOfDirsToBeCreated)
+
+	repostructureTest := NewRepoStructureExists("./")
+	result := repostructureTest.Test()
+	filesystem.CleanFiles(append(newListOfFilesToBeCreated, listOfDirsToBeCreated...))
+
+	if !result.Passed {
+		t.Errorf("There is multiple DEPENDENCIES files, test should pass.")
 	}
 }
 


### PR DESCRIPTION
The PR fixes reported issue with regards to multiple DEPENDENCIES files presence in repository structure. With the fix quality check accepts now the case where there is more files with DEPENDENCIES prefix, i.e. DEPENDENCIES_FRONTEND, DEPENDENCIES_BACKEND. 

Fixes https://github.com/eclipse-tractusx/sig-infra/issues/230
Updates https://github.com/eclipse-tractusx/sig-infra/issues/93

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
