### PR TITLE
fix: exclude non-chart directories at helm chart structure check

### DIFF
--- a/pkg/helm/helmchart_structure_exists.go
+++ b/pkg/helm/helmchart_structure_exists.go
@@ -54,7 +54,6 @@ func (r *HelmStructureExists) ExternalDescription() string {
 func (r *HelmStructureExists) Test() *tractusx.QualityResult {
 	helmStructureFiles := []string{
 		".helmignore",
-		"Chart.yaml",
 		"LICENSE",
 		"README.md",
 		"values.yaml",
@@ -73,15 +72,16 @@ func (r *HelmStructureExists) Test() *tractusx.QualityResult {
 	var missingFiles []string
 	var chartYamlFiles []string
 	for _, hc := range helmCharts {
-		if hc.IsDir() {
-			for _, fname := range helmStructureFiles {
-				fpath := filepath.Join(chartDir, hc.Name(), fname)
-				isMissing := filesystem.CheckMissingFiles([]string{fpath})
-				if fname == "Chart.yaml" && isMissing == nil {
-					chartYamlFiles = append(chartYamlFiles, fpath)
-				} else if isMissing != nil {
-					missingFiles = append(missingFiles, isMissing...)
-				}
+		if _, err := os.Stat(path.Join(chartDir, hc.Name(), "Chart.yaml")); !hc.IsDir() || err != nil {
+            continue
+        }
+		for _, fname := range helmStructureFiles {
+			fpath := filepath.Join(chartDir, hc.Name(), fname)
+			isMissing := filesystem.CheckMissingFiles([]string{fpath})
+			if fname == "Chart.yaml" && isMissing == nil {
+				chartYamlFiles = append(chartYamlFiles, fpath)
+			} else if isMissing != nil {
+				missingFiles = append(missingFiles, isMissing...)
 			}
 		}
 	}

--- a/pkg/helm/helmchart_structure_exists_test.go
+++ b/pkg/helm/helmchart_structure_exists_test.go
@@ -50,6 +50,7 @@ func TestShouldFailForEmptyChartsDir(t *testing.T) {
 
 func TestShouldFailIfHelmStructureIsMissing(t *testing.T) {
 	os.MkdirAll("charts/exampleChart", 0750)
+	filesystem.CreateFiles([]string{"charts/exampleChart/Chart.yaml"})
 	defer os.RemoveAll("charts")
 
 	helmStructureTest := NewHelmStructureExists("./")


### PR DESCRIPTION
The PR aim is to fix helm chart structure check excluding helper/config folders in the "charts" directory.

Updates https://github.com/eclipse-tractusx/sig-infra/issues/93
Fixes https://github.com/eclipse-tractusx/sig-infra/issues/253

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
