### PR TITLE
fix: exclude non-chart directories at helm chart structure check

### DIFF
--- a/pkg/helm/helmchart_structure_exists.go
+++ b/pkg/helm/helmchart_structure_exists.go
@@ -78,7 +78,7 @@ func (r *HelmStructureExists) Test() *tractusx.QualityResult {
 			continue
 		}
 		chartYamlFiles = append(chartYamlFiles, chartYamlPath)
-		missingFiles = append(missingFiles, getMissingChartFiles(path.Join(chartDir, hc.Name()))...)
+		getMissingChartFiles(path.Join(chartDir, hc.Name()), &missingFiles)
 	}
 
 	if len(chartYamlFiles) > 0 {
@@ -88,7 +88,6 @@ func (r *HelmStructureExists) Test() *tractusx.QualityResult {
 			errorDescriptionCharts += msg
 		}
 	}
-
 	if len(missingFiles) > 0 || !chartsValid {
 		return &tractusx.QualityResult{ErrorDescription: "+ Following Helm Chart structure files are missing: " + strings.Join(missingFiles, ", ") +
 			errorDescriptionCharts}
@@ -96,15 +95,13 @@ func (r *HelmStructureExists) Test() *tractusx.QualityResult {
 	return &tractusx.QualityResult{Passed: true}
 }
 
-func getMissingChartFiles(chartPath string) []string {
-	var missingFiles []string
+func getMissingChartFiles(chartPath string, missingFiles *[]string) {
 	for _, fileToCheck := range helmStructureFiles {
 		missingFile := filesystem.CheckMissingFiles([]string{path.Join(chartPath, fileToCheck)})
 		if missingFile != nil {
-			missingFiles = append(missingFiles, missingFile...)
+			*missingFiles = append(*missingFiles, missingFile...)
 		}
 	}
-	return missingFiles
 }
 
 func validateChart(chartyamlfile string) (bool, string) {

--- a/pkg/helm/helmchart_structure_exists.go
+++ b/pkg/helm/helmchart_structure_exists.go
@@ -54,7 +54,6 @@ func (r *HelmStructureExists) ExternalDescription() string {
 func (r *HelmStructureExists) Test() *tractusx.QualityResult {
 	helmStructureFiles := []string{
 		".helmignore",
-		"Chart.yaml",
 		"LICENSE",
 		"README.md",
 		"values.yaml",
@@ -73,15 +72,16 @@ func (r *HelmStructureExists) Test() *tractusx.QualityResult {
 	var missingFiles []string
 	var chartYamlFiles []string
 	for _, hc := range helmCharts {
-		if hc.IsDir() {
-			for _, fname := range helmStructureFiles {
-				fpath := filepath.Join(chartDir, hc.Name(), fname)
-				isMissing := filesystem.CheckMissingFiles([]string{fpath})
-				if fname == "Chart.yaml" && isMissing == nil {
-					chartYamlFiles = append(chartYamlFiles, fpath)
-				} else if isMissing != nil {
-					missingFiles = append(missingFiles, isMissing...)
-				}
+		if _, err := os.Stat(path.Join(chartDir, hc.Name(), "Chart.yaml")); !hc.IsDir() || err != nil {
+            continue
+        }
+		for _, fname := range helmStructureFiles {
+			fpath := filepath.Join(chartDir, hc.Name(), fname)
+			isMissing := filesystem.CheckMissingFiles([]string{fpath})
+			if fname == "Chart.yaml" && isMissing == nil {
+				chartYamlFiles = append(chartYamlFiles, fpath)
+			} else if isMissing != nil {
+				missingFiles = append(missingFiles, isMissing...)
 			}
 		}
 	}

--- a/pkg/helm/helmchart_structure_exists_test.go
+++ b/pkg/helm/helmchart_structure_exists_test.go
@@ -37,14 +37,14 @@ func TestShouldPassIfHelmDirIsMissing(t *testing.T) {
 	}
 }
 
-func TestShouldFailForEmptyChartsDir(t *testing.T) {
+func TestShouldPassForEmptyChartsDir(t *testing.T) {
 	os.Mkdir("charts", 0750)
 	defer os.Remove("charts")
 
 	result := NewHelmStructureExists("./").Test()
 
-	if result.Passed {
-		t.Errorf("Helm directory doesn't contain any charts hence test should fail.")
+	if !result.Passed {
+		t.Errorf("Helm directory doesn't contain any charts hence test should pass.")
 	}
 }
 

--- a/pkg/helm/helmchart_structure_exists_test.go
+++ b/pkg/helm/helmchart_structure_exists_test.go
@@ -50,6 +50,7 @@ func TestShouldFailForEmptyChartsDir(t *testing.T) {
 
 func TestShouldFailIfHelmStructureIsMissing(t *testing.T) {
 	os.MkdirAll("charts/exampleChart", 0750)
+	filesystem.CreateFiles([]string{"charts/exampleChart/Chart.yaml"})
 	defer os.RemoveAll("charts")
 
 	helmStructureTest := NewHelmStructureExists("./")


### PR DESCRIPTION
The PR aim is to fix helm chart structure check excluding helper/config folders in the "charts" directory.

Updates https://github.com/eclipse-tractusx/sig-infra/issues/93
Fixes https://github.com/eclipse-tractusx/sig-infra/issues/253
