### PR TITLE
feat: enabling multiple platforms binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,10 @@ name: Create GitHub Release
 
 on:
   workflow_dispatch:
+    inputs:
+      version: 
+        description: "The version to release. For example, 1.0.0"
+        required: true
   push:
     tags:
       - "v*.*.*"
@@ -33,15 +37,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux, darwin, windows]
-        goarch: ['386', amd64]
-        include:
-          - os: darwin
-            version: [arm, arm64]
+        # goos: [linux, darwin, windows]
+        # goarch: ['386', amd64]
+        goos: [linux, windows]
+        goarch: [amd64]
+        # include:
+        #   - os: darwin
+        #     version: [arm, arm64]
     steps:
       - uses: actions/checkout@v3
         with:
+          # fetch-tags: true
           fetch-depth: 0
+          # ref: v0.7.0
 
       - name: Set up Go
         uses: actions/setup-go@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           # fetch-tags: true
-          fetch-depth: 0
+          fetch-depth: 1
           # ref: v0.7.0
 
       - name: Set up Go
@@ -59,7 +59,12 @@ jobs:
       - name: Gather version facts
         id: version
         run: |
-          tag=${GITHUB_REF/refs\/tags\//}
+          if [[ ${{ github.event_name == 'workflow_dispatch' }} == true ]]; then
+            tag=${{ inputs.version }}
+          else
+            tag=${GITHUB_REF/refs\/tags\//}
+          fi
+          # tag=${GITHUB_REF/refs\/tags\//}
           version=${tag#v}
           major=${version%%.*}
           echo "tag=${tag}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@
 name: Create GitHub Release
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v*.*.*"
@@ -30,6 +31,13 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, darwin, windows]
+        goarch: ['386', amd64]
+        include:
+          - os: darwin
+            version: [arm, arm64]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -51,7 +59,7 @@ jobs:
           echo "major=${major}" >> $GITHUB_OUTPUT
 
       - name: Build binary
-        run: go build -o ${{ github.workspace }}/bin/${{ env.APP_NAME }}-${{ steps.version.outputs.version }}
+        run: env GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o ${{ github.workspace }}/bin/${{ env.APP_NAME }}-${{ steps.version.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}
         working-directory: ${{ github.workspace }}
 
       - name: Create GitHub release
@@ -70,8 +78,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/bin/${{ env.APP_NAME }}-${{ steps.version.outputs.version }}
-          asset_name: ${{ env.APP_NAME }}-${{ steps.version.outputs.version }}
+          asset_path: ${{ github.workspace }}/bin/${{ env.APP_NAME }}-${{ steps.version.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}
+          asset_name: ${{ env.APP_NAME }}-${{ steps.version.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}
           asset_content_type: application/octet-stream
 
       - name: Force update major tag

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,11 +20,6 @@
 name: Create GitHub Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      version: 
-        description: "The version to release. For example, 1.0.0"
-        required: true
   push:
     tags:
       - "v*.*.*"
@@ -35,46 +30,24 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # goos: [linux, darwin, windows]
-        # goarch: ['386', amd64]
-        goos: [linux, windows]
-        goarch: [amd64]
-        # include:
-        #   - os: darwin
-        #     version: [arm, arm64]
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v3
         with:
-          # fetch-tags: true
-          fetch-depth: 1
-          # ref: v0.7.0
-
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: "go.mod"
-
+          fetch-depth: 0
       - name: Gather version facts
         id: version
         run: |
-          if [[ ${{ github.event_name == 'workflow_dispatch' }} == true ]]; then
-            tag=${{ inputs.version }}
-          else
-            tag=${GITHUB_REF/refs\/tags\//}
-          fi
-          # tag=${GITHUB_REF/refs\/tags\//}
+          tag=${GITHUB_REF/refs\/tags\//}
           version=${tag#v}
           major=${version%%.*}
+          major_minor=${version%.*}
           echo "tag=${tag}" >> $GITHUB_OUTPUT
           echo "version=${version}" >> $GITHUB_OUTPUT
           echo "major=${major}" >> $GITHUB_OUTPUT
-
-      - name: Build binary
-        run: env GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o ${{ github.workspace }}/bin/${{ env.APP_NAME }}-${{ steps.version.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}
-        working-directory: ${{ github.workspace }}
-
+          echo "major_minor=${major_minor}" >> $GITHUB_OUTPUT
       - name: Create GitHub release
         id: create_release
         uses: release-drafter/release-drafter@v5
@@ -84,18 +57,44 @@ jobs:
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Force update major tag
+        run: |
+          git tag v${{ steps.version.outputs.major }} ${{ steps.version.outputs.tag }} -f
+          git push origin refs/tags/v${{ steps.version.outputs.major }} -f
+          git tag v${{ steps.version.outputs.major_minor }} ${{ steps.version.outputs.tag }} -f
+          git push origin refs/tags/v${{ steps.version.outputs.major_minor }} -f
 
+  build:
+    runs-on: ubuntu-latest
+    needs: release
+    strategy:
+      matrix:
+        goos: [linux, windows, darwin]
+        goarch: [amd64]
+        include:
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: '386'
+          - goos: linux
+            goarch: '386'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: "go.mod"
+      - name: Build binary
+        run: env GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o ${{ github.workspace }}/bin/${{ env.APP_NAME }}-${{ needs.release.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}
+        working-directory: ${{ github.workspace }}
       - name: Upload release assets
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ github.workspace }}/bin/${{ env.APP_NAME }}-${{ steps.version.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}
-          asset_name: ${{ env.APP_NAME }}-${{ steps.version.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/bin/${{ env.APP_NAME }}-${{ needs.release.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}
+          asset_name: ${{ env.APP_NAME }}-${{ needs.release.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}
           asset_content_type: application/octet-stream
-
-      - name: Force update major tag
-        run: |
-          git tag v${{ steps.version.outputs.major }} ${{ steps.version.outputs.tag }} -f
-          git push origin refs/tags/v${{ steps.version.outputs.major }} -f

--- a/action.yaml
+++ b/action.yaml
@@ -23,7 +23,7 @@ inputs:
   version:
     description: The version of the quality checks release to use
     required: true
-    default: "0.6.0"
+    default: "0.7.0"
 
 runs:
   using: composite


### PR DESCRIPTION
The goal of the PR is to support binaries build for multiple os/architectures. The change was implemented in the existing release workflow. It introduces binaries builds for following platforms:
- linux/386
- linux/amd64
- windows/386
- windows/amd64
- darwin/amd64
- Darwin/arm64

Fixes https://github.com/eclipse-tractusx/tractusx-quality-checks/issues/27
Updates https://github.com/eclipse-tractusx/sig-infra/issues/93