### PR TITLE
docs: how to setup tractusx quality check pre-commit hook description

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ this repository.
 
 It is possible to add quality checks as git pre-commit hook in the repository which will run checks triggered by git commit command. To achieve that please follow below steps:
 
-1. Download latest version of the tractusx-quality-checks tool for your platform under Asset section at https://github.com/eclipse-tractusx/tractusx-quality-checks/releases
+1. Download latest version of the tractusx-quality-checks tool for your platform under Asset section at https://github.com/eclipse-tractusx/tractusx-quality-checks/releases/latest
 2. Add executable permission if necessary and copy the binary (changing file name to tractusx-quality-checks) into one of the $PATH location depending on your OS.
 
 #### macOS example:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ this repository.
 
 ## Git pre-commit hook
 
-It is possible to add quality checks as git pre-commit hook in the repository which will run checks triggered by git commit command. To achive that flease follow below steps:
+It is possible to add quality checks as git pre-commit hook in the repository which will run checks triggered by git commit command. To achieve that please follow below steps:
 
 1. Download latest version of the tractusx-quality-checks tool for your platform under Asset section at https://github.com/eclipse-tractusx/tractusx-quality-checks/releases
 2. Add executable permission if necessary and copy the binary (changing file name to tractusx-quality-checks) into one of the $PATH location depending on your OS.
@@ -30,7 +30,7 @@ $ chmod +x tractusx-quality-checks-0.8.0-darwin-arm64
 $ sudo cp tractusx-quality-checks-0.8.0-darwin-arm64 /usr/local/bin/tractusx-quality-checks
 ```
 
-3. Inside your repo copy below to .git/hooks/pre-commit inside your repo:
+3. Inside your repo copy below to .git/hooks/pre-commit:
 
 ```
     #!/usr/bin/env bash

--- a/README.md
+++ b/README.md
@@ -16,6 +16,38 @@ are available as library to use in multiple usecases. These could be:
 If you want to build the command locally, you just need Golang version 1.20 and run `go build` on the root level of
 this repository.
 
+## Git pre-commit hook
+
+It is possible to add quality checks as git pre-commit hook in the repository which will run checks triggered by git commit command. To achive that flease follow below steps:
+
+1. Download latest version of the tractusx-quality-checks tool for your platform under Asset section at https://github.com/eclipse-tractusx/tractusx-quality-checks/releases
+2. Add executable permission if necessary and copy the binary (changing file name to tractusx-quality-checks) into one of the $PATH location depending on your OS.
+
+#### macOS example:
+
+```
+$ chmod +x tractusx-quality-checks-0.8.0-darwin-arm64
+$ sudo cp tractusx-quality-checks-0.8.0-darwin-arm64 /usr/local/bin/tractusx-quality-checks
+```
+
+3. Inside your repo copy below to .git/hooks/pre-commit inside your repo:
+
+```
+    #!/usr/bin/env bash
+    # ^ Note the above "shebang" line. This says "This is an executable shell script"
+    # Name this script "pre-commit" and place it in the ".git/hooks/" directory
+
+    # Exit immediately with that command's exit status if the command fails
+    set -eo pipefail
+
+    # Run Tractus-X quality checks
+    tractusx-quality-checks checkLocal
+    echo -e "\n\n--- TRG checks passed! ---\n\n"
+```
+
+5. Make .git/hooks/pre-commit executable.
+6. Pre-commit setup is complete and initiates checks each time git commit is ran. 
+
 ## Custom GitHub action
 
 The `tractusx-quality-checks` can be run as a GitHub action. This action is build as a


### PR DESCRIPTION
PR to describe how to setup tractusx quality check pre-commit hook. It allows developer to validate TRGs compliance locally. Speeds up the process and helps determine potential issues before it's pushed to remote repository. 

Fixes https://github.com/eclipse-tractusx/sig-infra/issues/90
Updates https://github.com/eclipse-tractusx/sig-infra/issues/93