### PR TITLE
chore: metadata enhancement with repo category

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -20,7 +20,7 @@
 
 product: "tractusx-quality-checks"
 leadingRepository: "https://github.com/eclipse-tractusx/sig-infra"
-supportingRepository: true
+repoCategory: "support"
 repositories:
     - name: "Tractus-X quality checks"
       usage: "automated release guidelines checks"

--- a/.tractusx
+++ b/.tractusx
@@ -20,6 +20,7 @@
 
 product: "tractusx-quality-checks"
 leadingRepository: "https://github.com/eclipse-tractusx/sig-infra"
+supportingRepository: true
 repositories:
     - name: "Tractus-X quality checks"
       usage: "automated release guidelines checks"

--- a/pkg/tractusx/metadata.go
+++ b/pkg/tractusx/metadata.go
@@ -63,7 +63,7 @@ func MetadataFromLocalFile(dir string) (*Metadata, error) {
 	metadataFileAsBytes, err := os.ReadFile(path.Join(dir, MetadataFilename))
 
 	if err != nil {
-		fmt.Println(fmt.Sprintf("Could not read Tractus-X metadatafile from default location: %s", MetadataFilename))
+		fmt.Printf("Could not read Tractus-X metadatafile from default location: %s\n", MetadataFilename)
 		return nil, err
 	}
 

--- a/pkg/tractusx/metadata.go
+++ b/pkg/tractusx/metadata.go
@@ -30,10 +30,10 @@ import (
 const MetadataFilename = ".tractusx"
 
 type Metadata struct {
-	ProductName          string       `yaml:"product"`
-	LeadingRepository    string       `yaml:"leadingRepository"`
-	SupportingRepository bool         `yaml:"supportingRepository"`
-	Repositories         []Repository `yaml:"repositories"`
+	ProductName       string       `yaml:"product"`
+	LeadingRepository string       `yaml:"leadingRepository"`
+	RepoCategory      string       `yaml:"repoCategory"`
+	Repositories      []Repository `yaml:"repositories"`
 }
 
 type Repository struct {

--- a/pkg/tractusx/metadata.go
+++ b/pkg/tractusx/metadata.go
@@ -30,9 +30,10 @@ import (
 const MetadataFilename = ".tractusx"
 
 type Metadata struct {
-	ProductName       string       `yaml:"product"`
-	LeadingRepository string       `yaml:"leadingRepository"`
-	Repositories      []Repository `yaml:"repositories"`
+	ProductName          string       `yaml:"product"`
+	LeadingRepository    string       `yaml:"leadingRepository"`
+	SupportingRepository bool         `yaml:"supportingRepository"`
+	Repositories         []Repository `yaml:"repositories"`
 }
 
 type Repository struct {

--- a/pkg/tractusx/metadata_test.go
+++ b/pkg/tractusx/metadata_test.go
@@ -29,6 +29,7 @@ import (
 var metadataFromTestTemplate = Metadata{
 	ProductName:       "sig-infra",
 	LeadingRepository: "https://github.com/eclipse-tractusx/sig-infra",
+	RepoCategory:      "special",
 	Repositories: []Repository{
 		{
 			Name:             "sig-infra",

--- a/pkg/tractusx/test/metadata_test_template.yaml
+++ b/pkg/tractusx/test/metadata_test_template.yaml
@@ -20,6 +20,7 @@
 
 product: "sig-infra"
 leadingRepository: "https://github.com/eclipse-tractusx/sig-infra"
+repoCategory:      "special"
 repositories:
   - name: "sig-infra"
     usage: "Contains issue templates and workflows"


### PR DESCRIPTION
PR to enhance metadata structure including repository category. The option is to be used in the dashboard in order to present categorised repositories in separate sections. PR includes also .tractusx update with populated flag.

Updates https://github.com/eclipse-tractusx/sig-infra/issues/261
Updates https://github.com/eclipse-tractusx/sig-infra/issues/93