### PR TITLE
feat: web format errors

### DIFF
--- a/pkg/container/allowed_base_image_check.go
+++ b/pkg/container/allowed_base_image_check.go
@@ -71,16 +71,21 @@ func (a *AllowedBaseImage) Test() *txqualitychecks.QualityResult {
 		}
 	}
 
-	return &txqualitychecks.QualityResult{Passed: checkPassed, ErrorDescription: buildErrorDescription(deniedBaseImages)}
+	return &txqualitychecks.QualityResult{Passed: checkPassed, ErrorDescription: buildErrorDescription(deniedBaseImages, "cli"), ErrorDescriptionWeb: buildErrorDescription(deniedBaseImages, "web") }
 }
 
 func (a *AllowedBaseImage) IsOptional() bool {
 	return false
 }
 
-func buildErrorDescription(deniedImages []string) string {
+// Function to return error message of failed test.
+// There are two types of formatting: cli (default) and web
+func buildErrorDescription(deniedImages []string, errorFormat string) string {
 	if len(deniedImages) == 0 {
 		return ""
+	}
+	if strings.EqualFold(errorFormat, "web") {
+		return "Dockerfile(s) use not approved images:<br>"+strings.Join(deniedImages,"<br>")
 	}
 	return "We want to align on docker base images. We detected a Dockerfile specifying " +
 		strings.Join(deniedImages, ", ") + "\n\tAllowed images are: \n\t - " +

--- a/pkg/helm/helmchart_structure_exists.go
+++ b/pkg/helm/helmchart_structure_exists.go
@@ -90,7 +90,10 @@ func (r *HelmStructureExists) Test() *tractusx.QualityResult {
 
 	if len(missingFiles) > 0 || !chartsValid {
 		errMsg := "+ Following Helm Chart structure files are missing: " + strings.Join(missingFiles, ", ") + errorDescriptionCharts
-		return &tractusx.QualityResult{ErrorDescription: errMsg, ErrorDescriptionWeb: strings.ReplaceAll(errMsg, "\n", "<br>")}
+		if tractusx.ErrorOutputFormat == tractusx.WebErrOutputFormat {
+			return &tractusx.QualityResult{ErrorDescription: strings.ReplaceAll(errMsg, "\n", "<br>")}
+		}
+		return &tractusx.QualityResult{ErrorDescription: errMsg}
 	}
 	return &tractusx.QualityResult{Passed: true}
 }

--- a/pkg/helm/helmchart_structure_exists.go
+++ b/pkg/helm/helmchart_structure_exists.go
@@ -89,8 +89,8 @@ func (r *HelmStructureExists) Test() *tractusx.QualityResult {
 	}
 
 	if len(missingFiles) > 0 || !chartsValid {
-		return &tractusx.QualityResult{ErrorDescription: "+ Following Helm Chart structure files are missing: " + strings.Join(missingFiles, ", ") +
-			errorDescriptionCharts}
+		errMsg := "+ Following Helm Chart structure files are missing: " + strings.Join(missingFiles, ", ") + errorDescriptionCharts
+		return &tractusx.QualityResult{ErrorDescription: errMsg, ErrorDescriptionWeb: strings.ReplaceAll(errMsg, "\n", "<br>")}
 	}
 	return &tractusx.QualityResult{Passed: true}
 }

--- a/pkg/helm/helmchart_structure_exists.go
+++ b/pkg/helm/helmchart_structure_exists.go
@@ -105,14 +105,14 @@ func getMissingChartFiles(chartPath string, missingFiles *[]string) {
 	for _, fileToCheck := range helmStructureFiles {
 		missingFile := filesystem.CheckMissingFiles([]string{path.Join(chartPath, fileToCheck)})
 		if missingFile != nil {
-			*missingFiles = append(*missingFiles, missingFile...)
+			*missingFiles = append(*missingFiles, []string{strings.Split(missingFile[0], "charts")[1][1:]}...)
 		}
 	}
 }
 
 func validateChart(chartyamlfile string) (bool, string) {
 	isValid := true
-	returnMessage := "\n\t+ Analysis for " + chartyamlfile + ": "
+	returnMessage := "\n\t+ Analysis for " + strings.Split(chartyamlfile, "charts")[1][1:] + ": "
 	cyf := helm.ChartYamlFromFile(chartyamlfile)
 	missingFields := cyf.GetMissingMandatoryFields()
 

--- a/pkg/tractusx/types.go
+++ b/pkg/tractusx/types.go
@@ -40,9 +40,8 @@ type QualityGuideline interface {
 // QualityResult implements test result via Passed bool and in case of error a
 // ErrorDescription.
 type QualityResult struct {
-	Passed              bool
-	ErrorDescription    string
-	ErrorDescriptionWeb string
+	Passed           bool
+	ErrorDescription string
 }
 
 type Printer interface {
@@ -50,3 +49,10 @@ type Printer interface {
 	LogWarning(warning string)
 	LogError(err string)
 }
+
+var ErrorOutputFormat = CliErrOutputFormat
+
+const (
+	CliErrOutputFormat = iota
+	WebErrOutputFormat = iota
+)

--- a/pkg/tractusx/types.go
+++ b/pkg/tractusx/types.go
@@ -40,8 +40,9 @@ type QualityGuideline interface {
 // QualityResult implements test result via Passed bool and in case of error a
 // ErrorDescription.
 type QualityResult struct {
-	Passed           bool
-	ErrorDescription string
+	Passed              bool
+	ErrorDescription    string
+	ErrorDescriptionWeb string
 }
 
 type Printer interface {


### PR DESCRIPTION
PR to add quality checks web optimised. New struct field was added to store web error messages, to be used by quality dashboard for better user experience. Currently are two ways to present err message CLI (default) and WEB. Allowed base image and helm structure checks have been adopted to new method. 

Updates https://github.com/eclipse-tractusx/sig-infra/issues/265