### PR TITLE
chore(build): run dash license check on each PR

### DIFF
--- a/.github/workflows/dash-licence-check.yaml
+++ b/.github/workflows/dash-licence-check.yaml
@@ -1,0 +1,40 @@
+# #############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+---
+
+name: "3rd Party Dependency Check (Eclipse Dash Tool)"
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  check-3rd-party-licences:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Run dash
+        id: run-dash
+        uses: eclipse-tractusx/sig-infra/.github/actions/run-dash@main
+        with:
+          dash_input: "go.sum"


### PR DESCRIPTION
## Description

This PR runs a dash-license check on each PR, to verify if the `DEPENDENCIES` file is up-to-date before merging to main
