### PR TITLE
feat: skip aligned base image check based on metadata config

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,28 @@
+# Tractus-X quality checks
+
+This documentation aims to guide you through using and enhancing the `tractusx-quality-checks` library.
+
+## Architecture and style decisions
+
+- tbd
+
+## The metadata file
+
+The `tractusx-quality-checks` rely on a metadata file to read product information and configuration for the checks.
+Specifics about that file can be found in [metadata_file.md](./metadata_file.md)
+
+## How to use the lib
+
+- tbd
+
+## Developing
+
+-tbd
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+- Source URL: [https://github.com/eclipse-tractusx/tractusx-quality-checks](https://github.com/eclipse-tractusx/tractusx-quality-checks)

--- a/docs/metadata_file.md
+++ b/docs/metadata_file.md
@@ -1,0 +1,90 @@
+# The Tractus-X metadata file
+
+The `tractusx-quality-checks` rely on a metadata file to read product information and configuration for the checks.
+The following section describe details like location, filename and the quality check configuration options, you can declare.
+
+## General metadata
+
+- Filename: `.tractusx`
+- Location: root of your repository
+
+Every [eclipse-tractusx](https://github.com/eclipse-tractusx/) repository is expected to have a `.tractusx` metadata file
+present. General metadata is only mandatory in the [leading product repository](https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-4) though.
+
+The structure for leading repository metadata is as follows:
+
+```yaml
+# Will be used on dashboard etc. to refer to your product; only mandatory in the leading repo
+product: "your-product-name"
+# mandatory info in every repo
+leadingRepository: "https://github.com/eclipse-tractusx/<your-leading-repo>"
+# optional section to refer to all of your teams repositories
+repositories:
+  - name: "your-product-repo"
+    usage: "Main documentation and release repo for <product>"
+    url: "https://github.com/eclipse-tractusx/<your-leading-repo>"
+  - name: "your-product-library"
+    usage: "A library supporting <product>, that is released separately"
+    url: "https://github.com/eclipse-tractusx/<your-product-lib>"
+```
+
+## Repository category
+
+There are release guidelines, that target specific repositories, like the leading one for example.
+In order to differentiate the repositories, a `repoCategory` can be set in the metadata file to clarify the role of the repository.
+The category is set like shown in the following snippet:
+
+```yaml
+repoCategory: "special" # default: product; available options: "special", "support", "product" 
+```
+
+## Quality check configuration
+
+The `.tractusx` metadata file does contain configuration options to specify treatment in regards to guideline checks.
+
+### Exclude Dockerfiles from aligned base image check (TRG 4.02)
+
+As defined in [TRG 4.02](https://eclipse-tractusx.github.io/docs/release/trg-4/trg-4-02), all of our Docker images, that
+are published to [DockerHub](https://hub.docker.com/u/tractusx/), have to be based on an aligned base image.
+
+To mark a Docker image as non-published and therefor skipping the aligned base image check, you can add the path to the
+respective `Dockerfile` in a `skipReleaseChecks.alignedBaseImage` section.
+
+Example:
+
+```yaml
+# section to explicitly skip certain release guideline checks
+skipReleaseChecks:
+  # Skip TRG 4.02 aligned base images; Specify the complete path and filename to the dockerfile that is used to build
+  # a non published Docker image. Path is treated relative to your repository root.
+  alignedBaseImage:
+    - "path/to/non-published/Dockerfile"
+    - "path/to/Dockerfile/only/used/in/testing-pipeline/Dockerfile.ui-tests"
+```
+
+
+## Full example
+
+The following snippet shows a complete example of a `.tractusx` metadata file with all its options.
+
+```yaml
+# Will be used on dashboard etc. to refer to your product; only mandatory in the leading repo
+product: "your-product-name"
+# mandatory info in every repo
+leadingRepository: "https://github.com/eclipse-tractusx/<your-leading-repo>"
+# default: product; available options: "special", "support", "product"
+repoCategory: "special"
+# optional section to refer to all of your teams repositories
+repositories:
+  - name: "your-product-repo"
+    usage: "Main documentation and release repo for <product>"
+    url: "https://github.com/eclipse-tractusx/<your-leading-repo>"
+  - name: "your-product-library"
+    usage: "A library supporting <product>, that is released separately"
+    url: "https://github.com/eclipse-tractusx/<your-product-lib>"
+# section to explicitly skip certain release guideline checks
+skipReleaseChecks:
+  alignedBaseImage:
+    - "/path/to/non-published/Dockerfile"
+
+```

--- a/internal/filesystem/filesystem_test.go
+++ b/internal/filesystem/filesystem_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 )
 
-var testFile string = "_testfile"
-var testDir string = "_testdir"
+var testFile = "_testfile"
+var testDir = "_testdir"
 
 func TestShouldPassIfFileGetsCreated(t *testing.T) {
 	CreateFiles([]string{testFile})

--- a/pkg/container/allowed_base_image_check.go
+++ b/pkg/container/allowed_base_image_check.go
@@ -91,6 +91,7 @@ func buildErrorDescription(deniedImages []string) string {
 		strings.Join(deniedImages, ", ") + "\n\tAllowed images are: \n\t - " +
 		strings.Join(baseImageAllowList, "\n\t - ")
 }
+
 func isAllowedBaseImage(image string) bool {
 	for _, imageFromAllowList := range baseImageAllowList {
 		if strings.Contains(image, imageFromAllowList) {

--- a/pkg/container/allowed_base_image_check.go
+++ b/pkg/container/allowed_base_image_check.go
@@ -56,13 +56,20 @@ func (a *AllowedBaseImage) ExternalDescription() string {
 
 func (a *AllowedBaseImage) Test() *tractusx.QualityResult {
 	foundDockerFiles := findDockerfilesAt(a.baseDir)
+	dockerfilesToSkip := getDockerfilePathsToIgnore(a.baseDir)
 
 	checkPassed := true
 	var deniedBaseImages []string
 	for _, dockerfilePath := range foundDockerFiles {
+		if containsString(dockerfilesToSkip, dockerfilePath) {
+			fmt.Printf("Dockerfile at path %s configured to skip", dockerfilePath)
+			continue
+		}
+
 		file, err := dockerfileFromPath(dockerfilePath)
 		if err != nil {
 			fmt.Printf("Could not read dockerfile from Path %s\n", dockerfilePath)
+			continue
 		}
 
 		if !isAllowedBaseImage(file.baseImage()) {
@@ -95,6 +102,24 @@ func buildErrorDescription(deniedImages []string) string {
 func isAllowedBaseImage(image string) bool {
 	for _, imageFromAllowList := range baseImageAllowList {
 		if strings.Contains(image, imageFromAllowList) {
+			return true
+		}
+	}
+	return false
+}
+
+func getDockerfilePathsToIgnore(dir string) []string {
+	file, err := tractusx.MetadataFromLocalFile(dir)
+	if err != nil {
+		return []string{}
+	}
+
+	return file.AlignedBaseImages
+}
+
+func containsString(slice []string, element string) bool {
+	for _, v := range slice {
+		if v == element {
 			return true
 		}
 	}

--- a/pkg/container/dockerfile.go
+++ b/pkg/container/dockerfile.go
@@ -30,8 +30,6 @@ import (
 	"strings"
 )
 
-const NoUserFound = "No User found"
-
 // dockerfile is a simple utility to create or read dockerfiles.
 // the commands are supposed to contain every single instruction of the Dockerfile it represents
 type dockerfile struct {
@@ -84,7 +82,7 @@ func (d *dockerfile) writeTo(path string) error {
 	defer file.Close()
 
 	for _, command := range d.commands {
-		file.WriteString(command + "\n")
+		_, _ = file.WriteString(command + "\n")
 	}
 
 	return nil
@@ -136,7 +134,7 @@ func findDockerfilesAt(dir string) []string {
 	fmt.Println("Start finding Dockerfiles at " + dir)
 	var foundFiles []string
 
-	filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
+	_ = filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
 		if !info.IsDir() && strings.Contains(info.Name(), "Dockerfile") {
 			foundFiles = append(foundFiles, path)
 		}

--- a/pkg/container/dockerfile_test.go
+++ b/pkg/container/dockerfile_test.go
@@ -66,8 +66,8 @@ func TestShouldFindMultipleDockerfiles(t *testing.T) {
 	tempDir := t.TempDir()
 	secondTempDir := t.TempDir()
 
-	newDockerfile().writeTo(tempDir)
-	newDockerfile().writeTo(secondTempDir)
+	_ = newDockerfile().writeTo(tempDir)
+	_ = newDockerfile().writeTo(secondTempDir)
 
 	foundFiles := findDockerfilesAt(path.Join(tempDir, "../"))
 
@@ -80,11 +80,11 @@ func TestShouldFindDockerfilesWithUnusualNames(t *testing.T) {
 	tempDir := t.TempDir()
 	dockerfile := newDockerfile()
 	dockerfile.filename = "Dockerfile.full"
-	dockerfile.writeTo(tempDir)
+	_ = dockerfile.writeTo(tempDir)
 	dockerfile.filename = "db.Dockerfile"
-	dockerfile.writeTo(tempDir)
+	_ = dockerfile.writeTo(tempDir)
 	dockerfile.filename = "Dockerfile-dev"
-	dockerfile.writeTo(tempDir)
+	_ = dockerfile.writeTo(tempDir)
 
 	foundFiles := findDockerfilesAt(tempDir)
 

--- a/pkg/helm/helmchart_structure_exists.go
+++ b/pkg/helm/helmchart_structure_exists.go
@@ -29,7 +29,7 @@ import (
 	"github.com/eclipse-tractusx/tractusx-quality-checks/pkg/tractusx"
 )
 
-var helmStructureFiles []string = []string{
+var helmStructureFiles = []string{
 	".helmignore",
 	"LICENSE",
 	"README.md",
@@ -98,7 +98,7 @@ func (r *HelmStructureExists) Test() *tractusx.QualityResult {
 	return &tractusx.QualityResult{Passed: true}
 }
 
-// Function to validate if provided is helm chart directory.
+// IsChartDirectory evaluates, if the given directory can be seen as helm chart directory
 func IsChartDirectory(dir string) bool {
 	chartYamlPath := path.Join(dir, "Chart.yaml")
 	_, err := os.Stat(chartYamlPath)

--- a/pkg/helm/helmchart_structure_exists_test.go
+++ b/pkg/helm/helmchart_structure_exists_test.go
@@ -38,7 +38,7 @@ func TestShouldPassIfHelmDirIsMissing(t *testing.T) {
 }
 
 func TestShouldPassForEmptyChartsDir(t *testing.T) {
-	os.Mkdir("charts", 0750)
+	_ = os.Mkdir("charts", 0750)
 	defer os.Remove("charts")
 
 	result := NewHelmStructureExists("./").Test()
@@ -49,7 +49,7 @@ func TestShouldPassForEmptyChartsDir(t *testing.T) {
 }
 
 func TestShouldFailIfHelmStructureIsMissing(t *testing.T) {
-	os.MkdirAll("charts/exampleChart", 0750)
+	_ = os.MkdirAll("charts/exampleChart", 0750)
 	filesystem.CreateFiles([]string{"charts/exampleChart/Chart.yaml"})
 	defer os.RemoveAll("charts")
 
@@ -83,7 +83,7 @@ func TestShouldPassIfHelmStructureExist(t *testing.T) {
 
 func TestShouldPassIfChartStructureExistsAtGivenBaseDir(t *testing.T) {
 	dir := t.TempDir()
-	os.MkdirAll(path.Join(dir, "charts", "exampleChart"), 0770)
+	_ = os.MkdirAll(path.Join(dir, "charts", "exampleChart"), 0770)
 	filesystem.CreateFiles([]string{
 		path.Join(dir, "charts/exampleChart/.helmignore"),
 		path.Join(dir, "charts/exampleChart/LICENSE"),

--- a/pkg/helm/resource_mgmt_check_test.go
+++ b/pkg/helm/resource_mgmt_check_test.go
@@ -78,7 +78,7 @@ func copyFile(dest string, source string, t *testing.T) {
 
 func setupChartBasics(dir string, values string, t *testing.T) {
 	testchartPath := path.Join("test", "charts", "testchart")
-	os.MkdirAll(path.Join(dir, "charts", "testchart", "templates"), 0770)
+	_ = os.MkdirAll(path.Join(dir, "charts", "testchart", "templates"), 0770)
 	copyFile(path.Join(dir, "charts", "testchart", "values.yaml"), path.Join(testchartPath, values), t)
 	copyFile(path.Join(dir, "charts", "testchart", "Chart.yaml"), path.Join(testchartPath, "Chart.yaml"), t)
 }

--- a/pkg/repo/repo_structure_exists_test.go
+++ b/pkg/repo/repo_structure_exists_test.go
@@ -110,8 +110,8 @@ func TestShouldPassWithMultipleDependenciesFiles(t *testing.T) {
 
 func setEnv(t *testing.T) {
 	copyTemplateFileTo(".tractusx", t)
-	os.Setenv("GITHUB_REPOSITORY", "eclipse-tractusx/sig-infra")
-	os.Setenv("GITHUB_REPOSITORY_OWNER", "tester")
+	_ = os.Setenv("GITHUB_REPOSITORY", "eclipse-tractusx/sig-infra")
+	_ = os.Setenv("GITHUB_REPOSITORY_OWNER", "tester")
 }
 
 func copyTemplateFileTo(path string, t *testing.T) {

--- a/pkg/repo/repoinfo.go
+++ b/pkg/repo/repoinfo.go
@@ -28,7 +28,7 @@ import (
 	"github.com/go-ini/ini"
 )
 
-// RepoInfo provides basic infor
+// RepoInfo is a struct to keep basic information about a repository
 type RepoInfo struct {
 	Owner    string
 	Reponame string

--- a/pkg/tractusx/metadata.go
+++ b/pkg/tractusx/metadata.go
@@ -34,12 +34,17 @@ type Metadata struct {
 	LeadingRepository string       `yaml:"leadingRepository"`
 	RepoCategory      string       `yaml:"repoCategory"`
 	Repositories      []Repository `yaml:"repositories"`
+	SkipReleaseChecks `yaml:"skipReleaseChecks"`
 }
 
 type Repository struct {
 	Name             string `yaml:"name"`
 	UsageDescription string `yaml:"usage"`
 	Url              string `yaml:"url"`
+}
+
+type SkipReleaseChecks struct {
+	AlignedBaseImages []string `yaml:"alignedBaseImage"`
 }
 
 // MetadataFromFile does take fileContent as byte slice and tries to deserialize it into Metadata.

--- a/pkg/tractusx/metadata_test.go
+++ b/pkg/tractusx/metadata_test.go
@@ -42,6 +42,11 @@ var metadataFromTestTemplate = Metadata{
 			Url:              "https://github.com/eclipse-tractusx/charts",
 		},
 	},
+	SkipReleaseChecks: SkipReleaseChecks{
+		AlignedBaseImages: []string{
+			"/path/to/non-published/Dockerfile",
+		},
+	},
 }
 
 const metadataTestFile = "./test/metadata_test_template.yaml"

--- a/pkg/tractusx/test/metadata_test_template.yaml
+++ b/pkg/tractusx/test/metadata_test_template.yaml
@@ -28,3 +28,6 @@ repositories:
   - name: "charts"
     usage: "Central Helm repository containing all released charts of Tractus-X"
     url: "https://github.com/eclipse-tractusx/charts"
+skipReleaseChecks:
+  alignedBaseImage:
+    - "/path/to/non-published/Dockerfile"

--- a/pkg/tractusx/types.go
+++ b/pkg/tractusx/types.go
@@ -19,6 +19,15 @@
 
 package tractusx
 
+// ErrorOutputFormat is used to control the output format of error message.
+// Before running QualityGuideline.Test(), set the value to your preferred output format
+var ErrorOutputFormat = CliErrOutputFormat
+
+const (
+	CliErrOutputFormat = iota
+	WebErrOutputFormat
+)
+
 // QualityGuideline represents the QualityGuideline to check as an interface.
 //
 // The interface provide information about Name, Description, ExternalDescription,
@@ -49,10 +58,3 @@ type Printer interface {
 	LogWarning(warning string)
 	LogError(err string)
 }
-
-var ErrorOutputFormat = CliErrOutputFormat
-
-const (
-	CliErrOutputFormat = iota
-	WebErrOutputFormat = iota
-)


### PR DESCRIPTION
## Description

This PR introduces a new section to our `.tractusx` metadata file. The section `skipReleaseChecks.alignedBaseImage` allows to configure file paths to `Dockerfiles`, that are not published to DockerHub. The configuration is based on trust and is not verified automatically. 

If Dockerfiles are configured to skip the aligned base image check, the automated TRG checks will not report issues on that Dockerfile, even if it is not based on images aligned via TRG 4.02.

This PR also adds a first chapter to the `/docs` folder. I think that can be useful in multiple ways

- We can link to documentation related to the metadata file and reference to it in the TRG, so we do not duplicate content
- We have an easier entry for everyone, who want to contribute
- We can document decisions and reasons behind them

related to eclipse-tractusx/sig-infra#309

