### PR TITLE
feat: env variable to set basedir for checkLocal

### DIFF
--- a/cmd/checkLocal.go
+++ b/cmd/checkLocal.go
@@ -42,9 +42,9 @@ var checkLocalCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Running local checks of eclipse-tractusx release guidelines")
 
-		basedir := "./"
-		if os.Getenv("CHECKLOCAL_BASEDIR") != "" {
-			basedir = os.Getenv("CHECKLOCAL_BASEDIR")
+		basedir := os.Getenv("CHECKLOCAL_BASEDIR")
+		if basedir == "" {
+			basedir = "./"
 		}
 
 		var releaseGuidelines = []tractusx.QualityGuideline{

--- a/cmd/checkLocal.go
+++ b/cmd/checkLocal.go
@@ -33,19 +33,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var releaseGuidelines = []tractusx.QualityGuideline{
-	container.NewAllowedBaseImage("./"),
-	container.NewNonRootContainer("./"),
-	docs.NewChangelogExists("./"),
-	docs.NewInstallExists("./"),
-	docs.NewReadmeExists("./"),
-	helm.NewHelmStructureExists("./"),
-	helm.NewResourceMgmt("./"),
-	irepo.NewDefaultBranch(),
-	repo.NewLeadingRepositoryDefined("./"),
-	repo.NewRepoStructureExists("./"),
-}
-
 // checkLocalCmd represents the checkLocal command
 var checkLocalCmd = &cobra.Command{
 	Use:   "checkLocal",
@@ -54,6 +41,25 @@ var checkLocalCmd = &cobra.Command{
 
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Running local checks of eclipse-tractusx release guidelines")
+
+		basedir := "./"
+		if os.Getenv("CHECKLOCAL_BASEDIR") != "" {
+			basedir = os.Getenv("CHECKLOCAL_BASEDIR")
+		}
+
+		var releaseGuidelines = []tractusx.QualityGuideline{
+			container.NewAllowedBaseImage(basedir),
+			container.NewNonRootContainer(basedir),
+			docs.NewChangelogExists(basedir),
+			docs.NewInstallExists(basedir),
+			docs.NewReadmeExists(basedir),
+			helm.NewHelmStructureExists(basedir),
+			helm.NewResourceMgmt(basedir),
+			irepo.NewDefaultBranch(),
+			repo.NewLeadingRepositoryDefined(basedir),
+			repo.NewRepoStructureExists(basedir),
+		}
+
 		runner := txqualitychecks.NewTestRunner(releaseGuidelines)
 		err := runner.Run()
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

A new environment variable called `CHECKLOCAL_BASEDIR` that can be used with the checkLocal cmd and changes the path for the TRG checks. It still defaults to "./" when not set.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
