### PR TITLE
refactor: make error cases clear in method signatures

### DIFF
--- a/pkg/helm/resource_mgmt_check.go
+++ b/pkg/helm/resource_mgmt_check.go
@@ -20,11 +20,15 @@
 package helm
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/eclipse-tractusx/tractusx-quality-checks/pkg/tractusx"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/engine"
 	"k8s.io/api/apps/v1"
@@ -75,15 +79,14 @@ func (r *ResourceMgmt) Test() *tractusx.QualityResult {
 
 		renderedChartManifests, errDesc := renderChart(path.Join(chartDir, helmchart.Name()))
 		if renderedChartManifests == nil {
-			errorDescription += errDesc
+			errorDescription += errDesc.Error()
 			continue
 		}
 
 		for manifestName, manifestContent := range renderedChartManifests {
-			isValid, errMsg := validateResourceSetting(manifestContent)
-			if !isValid {
-				errorDescription += fmt.Sprintf("\n\t[%s]: %s", manifestName, errMsg)
-				continue
+			err = validateResourceSetting(manifestContent)
+			if err != nil {
+				errorDescription += fmt.Sprintf("\n\t[%s]: %s.", manifestName, firstCharUppercase(err))
 			}
 		}
 	}
@@ -94,14 +97,15 @@ func (r *ResourceMgmt) Test() *tractusx.QualityResult {
 	return &tractusx.QualityResult{Passed: true}
 }
 
-func validateResourceSetting(k8sManifest string) (bool, string) {
+func validateResourceSetting(k8sManifest string) error {
 	var containers []core.Container
 
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	obj, groupVersionKind, err := decode([]byte(k8sManifest), nil, nil)
 
+	// Resource settings treated as valid, if manifest could not be decoded
 	if err != nil {
-		return true, ""
+		return nil
 	}
 
 	switch groupVersionKind.Kind {
@@ -113,31 +117,32 @@ func validateResourceSetting(k8sManifest string) (bool, string) {
 
 	for _, c := range containers {
 		if c.Resources.Requests == nil {
-			return false, "No resources requests found in the manifest."
+			return errors.New("no resources requests found in the manifest")
 		}
 		if c.Resources.Requests.Cpu().IsZero() || c.Resources.Requests.Memory().IsZero() {
-			return false, "CPU or Memory not defined in resources Requests."
+			return errors.New("CPU or Memory not defined in resources Requests")
 		}
 		if c.Resources.Limits == nil {
-			return false, "No resources limits found in the manifest."
+			return errors.New("no resources limits found in the manifest")
 		}
 		if c.Resources.Limits.Cpu().IsZero() || c.Resources.Limits.Memory().IsZero() {
-			return false, "CPU or Memory not defined in resources Limits."
+			return errors.New("CPU or Memory not defined in resources Limits")
 		}
 		if c.Resources.Requests.Cpu().MilliValue() == c.Resources.Limits.Cpu().MilliValue() {
-			return false, "Requested CPU can't be the same as Limit CPU. Limit should be 2-3 times higher."
+			return errors.New("requested CPU can't be the same as Limit CPU. Limit should be 2-3 times higher")
 		}
 		if c.Resources.Requests.Memory().MilliValue() != c.Resources.Limits.Memory().MilliValue() {
-			return false, "Requested Memory size must be equal to Limit Memory size."
+			return errors.New("requested Memory size must be equal to Limit Memory size")
 		}
 	}
-	return true, ""
+	return nil
 }
 
-func renderChart(chartPath string) (map[string]string, string) {
+func renderChart(chartPath string) (map[string]string, error) {
 	loadedChart, err := loader.Load(chartPath)
 	if err != nil {
-		return nil, fmt.Sprintf("\n\tCan't read %s helm chart.", chartPath)
+		fmt.Printf("Chart loading error: %s\n", err)
+		return nil, errors.New(fmt.Sprintf("\n\tCan't read %s helm chart.", chartPath))
 	}
 
 	finalValues := map[string]interface{}{
@@ -147,7 +152,19 @@ func renderChart(chartPath string) (map[string]string, string) {
 
 	renderedChart, err := engine.Render(loadedChart, finalValues)
 	if err != nil {
-		return nil, fmt.Sprintf("\n\tUnable to render helm chart %s.", chartPath)
+		fmt.Printf("Chart rendering error: %s\n", err)
+		return nil, errors.New(fmt.Sprintf("\n\tUnable to render helm chart %s.", chartPath))
 	}
-	return renderedChart, ""
+	return renderedChart, nil
+}
+
+func firstCharUppercase(err error) string {
+	split := strings.Split(err.Error(), " ")
+	result := cases.Title(language.English, cases.NoLower).String(split[0])
+
+	if len(split) > 1 {
+		result = result + " " + strings.Join(split[1:], " ")
+	}
+
+	return result
 }

--- a/pkg/helm/resource_mgmt_check_test.go
+++ b/pkg/helm/resource_mgmt_check_test.go
@@ -20,6 +20,7 @@
 package helm
 
 import (
+	"errors"
 	"os"
 	"path"
 	"testing"
@@ -65,6 +66,37 @@ func TestShouldFailIfMemRequestIsNotEqualMemLimitsAtSTS(t *testing.T) {
 	}
 }
 
+func TestShouldCapitalizeFirstLetterOfErrorMessage(t *testing.T) {
+	testCases := []struct {
+		err            error
+		expectedString string
+		errorIfFailing string
+	}{
+		{
+			err:            errors.New("requested CPU can't be the same as Limit CPU. Limit should be 2-3 times higher"),
+			expectedString: "Requested CPU can't be the same as Limit CPU. Limit should be 2-3 times higher",
+			errorIfFailing: "Should capitalize first letter of regular error string",
+		},
+		{
+			err:            errors.New("CPU or Memory not defined in resources Limits"),
+			expectedString: "CPU or Memory not defined in resources Limits",
+			errorIfFailing: "Should keep acronyms capitalized",
+		},
+		{
+			err:            errors.New("justOneWord"),
+			expectedString: "JustOneWord",
+			errorIfFailing: "A single word should also be capitalized",
+		},
+	}
+
+	for _, testCase := range testCases {
+		capitalizedString := firstCharUppercase(testCase.err)
+		if capitalizedString != testCase.expectedString {
+			t.Errorf("%s, \n\texpected:\t%s\n\tgot:\t\t%s", testCase.errorIfFailing, testCase.expectedString, capitalizedString)
+		}
+	}
+}
+
 func copyFile(dest string, source string, t *testing.T) {
 	templateFile, err := os.ReadFile(source)
 	if err != nil {
@@ -77,10 +109,10 @@ func copyFile(dest string, source string, t *testing.T) {
 }
 
 func setupChartBasics(dir string, values string, t *testing.T) {
-	testchartPath := path.Join("test", "charts", "testchart")
+	testChartPath := path.Join("test", "charts", "testchart")
 	_ = os.MkdirAll(path.Join(dir, "charts", "testchart", "templates"), 0770)
-	copyFile(path.Join(dir, "charts", "testchart", "values.yaml"), path.Join(testchartPath, values), t)
-	copyFile(path.Join(dir, "charts", "testchart", "Chart.yaml"), path.Join(testchartPath, "Chart.yaml"), t)
+	copyFile(path.Join(dir, "charts", "testchart", "values.yaml"), path.Join(testChartPath, values), t)
+	copyFile(path.Join(dir, "charts", "testchart", "Chart.yaml"), path.Join(testChartPath, "Chart.yaml"), t)
 }
 
 func setupK8SObject(dir string, manifest string, values string, t *testing.T) {


### PR DESCRIPTION
## Description

This PR can be seen as a proposal and is totally up for discussion.
What I want to emphasize with my changes is, that we should keep clear method signatures. Some of the functions I changed returned some kind of error state often represented by a boolean and an error description as string. This can be handled by using the builtin `error` object. In my opinion having an `error` as return type in the method signature does make it clearer, that there is an unwanted state. Looking at `(bool, string)` on the other hand does not make it as clear in my opinion and one has to check the variable names used to return the values.

I also amended the `getMissingChartFiles` in `pkg/helm/helmchart_structure_exists.go` by changing the parameters. 
In this case, the function took a parameter, that was "filled" by the function. I think this is a different approach to all of our other functions, that would return this value as return value and do not touch values passed as parameter

One odd thing I see currently is, that a lot of the error messages we have, are somewhat "aware" of their surroundings. Meaning, they are already packed with newlines or tab characters. This makes it hard to grasp the actual output in the end. 
I think what could help us is to actually use error objects in our method signatures, but not pack them with business related information and outputs